### PR TITLE
Fix for: "esriLoader should take an array of module names and return an array of modules #45"

### DIFF
--- a/src/services/esriLoader.js
+++ b/src/services/esriLoader.js
@@ -6,16 +6,21 @@
     angular.module('esri.map').factory('esriLoader', function ($q) {
         return function(moduleName){
             var deferred = $q.defer();
-
-            require([moduleName], function(module){
-                if(module){
-                    deferred.resolve(module);
-                } else {
-                    deferred.reject('Couldn\'t load ' + moduleName);
-                }
-            });
-
+            if (angular.isString(moduleName)) {
+                require([moduleName], function (obj) {
+                    deferred.resolve(obj);
+                });
+            }
+            else if (angular.isArray(moduleName)) {
+                require(moduleName, function (obj) {
+                    deferred.resolve(arguments);
+                });
+            }
+            else {
+                deferred.reject('An Array<String> or String is required to load modules.')
+            }
             return deferred.promise;
+
         };
     });
 


### PR DESCRIPTION
Extended the esriLoader to support an argument type of array as well as a string. The promise will now resolve either a single object when a string is input or an Array<object> when an array of strings is provided.