### PR TITLE
fix script path

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "Tom Wayson <twayson@esri.com> (http://tomwayson.com)"
   ],
   "description": "A collection of directives to help you use Esri maps and services in your Angular applications",
-  "main": ["dist/angular-esri-map.js", "angular-esri-map.min.js"],
+  "main": ["dist/angular-esri-map.js", "dist/angular-esri-map.min.js"],
   "keywords": [
     "Angular",
     "Esri"


### PR DESCRIPTION
The script files are both in the dist directory, jet the path for the angular-esri-map.min.js points to the parent directory. This fixes it.