### PR TITLE
Layer index ordering #101

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ Add or remove layers from the map programatically [#51](https://github.com/Esri/
 
 Set [definition expression option](https://developers.arcgis.com/javascript/jsapi/featurelayer-amd.html#featurelayer1) of feature layer when adding it to the map [#51](https://github.com/Esri/angular-esri-map/pull/51) [@eas604](https://github.com/eas604)
 
-**esriFeatureLayer** directive now accepts optional opacity and JSAPI construction layer options.  Opacity and definition expression act just like the visible option, and are watched for changes and can be adjusted at any time. [#97](https://github.com/Esri/angular-esri-map/issues/97) and [#100](https://github.com/Esri/angular-esri-map/issues/100)
+esriFeatureLayer directive now accepts optional opacity and JSAPI construction layer options.  Opacity and definition expression act just like the visible option, and are watched for changes and can be adjusted at any time. [#97](https://github.com/Esri/angular-esri-map/issues/97) and [#100](https://github.com/Esri/angular-esri-map/issues/100)
+
+esriFeatureLayers can be consistently added to the map with top-to-bottom layer ordering. [#101](https://github.com/Esri/angular-esri-map/issues/101)
 
 ### Documentation
 
@@ -21,7 +23,7 @@ Examples pages are now driven by configurable JSON and have more consistent titl
 
 Using `ng-options` for zoom level select Set Center and Zoom example page so that it has the correct value selected initially [c8659fce](https://github.com/Esri/angular-esri-map/commit/c8659fce94a94c5361a4cb047410b7cf0c4c87e4)
 
-Feature-layers example now includes adjustable layer opacity, definition expression, and additional information on the **esriFeatureLayer** directive options [#97](https://github.com/Esri/angular-esri-map/issues/97) and [#100](https://github.com/Esri/angular-esri-map/issues/100).
+Feature-layers example now includes adjustable layer opacity, definition expression, and additional information on the esriFeatureLayer directive options [#97](https://github.com/Esri/angular-esri-map/issues/97) and [#100](https://github.com/Esri/angular-esri-map/issues/100).
 
 ### Tests
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Once you've added the module to your application, you can use the sample code be
     </head>
     <body ng-controller="MapController">
     <esri-map id="map" center="map.center" zoom="map.zoom" basemap="topo">
-        <esri-feature-layer url="http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Portland_Parks/FeatureServer/0"></esri-feature-layer>
         <esri-feature-layer url="http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0"></esri-feature-layer>
+        <esri-feature-layer url="http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Portland_Parks/FeatureServer/0"></esri-feature-layer>
     </esri-map>
     <p>Lat: {{ map.center.lat | number:3 }}, Lng: {{ map.center.lng | number:3 }}, Zoom: {{map.zoom}}</p>
         <script type="text/javascript" src="http://js.arcgis.com/3.14compact"></script>

--- a/docs/app/examples/feature-layers.html
+++ b/docs/app/examples/feature-layers.html
@@ -1,23 +1,21 @@
 <h2>Feature Layers</h2>
 <!-- add map to page and bind to scope map parameters -->
 <esri-map id="map" center="map.center" zoom="map.zoom" basemap="topo">
-    <!-- a feature layer with an optional opacity property -->
-    <esri-feature-layer 
-        url="http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Portland_Parks/FeatureServer/0"
-        opacity="{{map.parksOpacity}}"
-        >
-    </esri-feature-layer>
-    <!-- a feature layer with optional visible and definition-expression properties -->
+    <!-- a feature layer with optional visible and definition-expression attributes -->
     <esri-feature-layer 
         url="http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0"
         visible="{{map.showTrees}}" 
-        definition-expression="{{map.treesDefExpression}}"
-        >
+        definition-expression="{{map.treesDefExpression}}">
     </esri-feature-layer>
-    <!-- a feature layer with an optional layer-options property-->
+    <!-- a feature layer with an optional layer-options attribute -->
     <esri-feature-layer 
         url="http://services.arcgis.com/rOo16HdIMeOBI4Mb/ArcGIS/rest/services/Portland_Light_Rail_Lines/FeatureServer/0"
         layer-options="map.railLayerOptions">
+    </esri-feature-layer>
+    <!-- a feature layer with an optional opacity attribute -->
+    <esri-feature-layer 
+        url="http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Portland_Parks/FeatureServer/0"
+        opacity="{{map.parksOpacity}}">
     </esri-feature-layer>
 </esri-map>
 

--- a/src/directives/esriFeatureLayer.js
+++ b/src/directives/esriFeatureLayer.js
@@ -125,8 +125,9 @@
                 var mapController = controllers[1];
 
                 layerController.getLayer().then(function(layer) {
-                    // add layer
-                    mapController.addLayer(layer);
+                    // add layer at index position 0
+                    // so that layers can be declaratively added to map in top-to-bottom order
+                    mapController.addLayer(layer, 0);
 
                     // Look for layerInfo related attributes. Add them to the map's layerInfos array for access in other components
                     mapController.addLayerInfo({

--- a/src/directives/esriMap.js
+++ b/src/directives/esriMap.js
@@ -218,9 +218,11 @@
                 };
 
                 // adds the layer, returns the promise that will be resolved with the result of map.addLayer
-                this.addLayer = function(layer) {
+                this.addLayer = function(layer, index) {
+                    // layer: valid JSAPI layer
+                    // index: optional <Number>; likely only used internally by, for example, esriFeatureLayer
                     return this.getMap().then(function(map) {
-                        return map.addLayer(layer);
+                        return map.addLayer(layer, index);
                     });
                 };
 

--- a/test/e2e/specs/feature-layers.js
+++ b/test/e2e/specs/feature-layers.js
@@ -7,12 +7,12 @@ describe('Feature Layers', function() {
     var zoomIn = element(by.css('.esriSimpleSliderIncrementButton'));
     var map = element(by.id('map'));
     var mapGraphics = element(by.id('map_gc'));
-    // polygon
-    var featureLayer1 = element(by.id('graphicsLayer1_layer'));
     // point
-    var featureLayer2 = element(by.id('graphicsLayer2_layer'));
+    var pointFeatureLayer = element(by.id('graphicsLayer1_layer'));
     // polyline, with unique ID defined by JSAPI constructor options
-    var featureLayer3 = element(by.id('PortlandLightRail_layer'));
+    var polylineFeatureLayer = element(by.id('PortlandLightRail_layer'));
+    // polygon
+    var polygonFeatureLayer = element(by.id('graphicsLayer2_layer'));
 
     beforeAll(function() {
         // refer to conf.js to get the baseUrl that is prepended
@@ -25,16 +25,16 @@ describe('Feature Layers', function() {
         helper.waitUntilElementIsReady(map);
         helper.waitUntilElementIsReady(mapGraphics);
 
-        helper.getAsyncAttributeValue(featureLayer1, 'data-geometry-type').then(function(value) {
-            expect(value).toEqual('polygon');
-        });
-
-        helper.getAsyncAttributeValue(featureLayer2, 'data-geometry-type').then(function(value) {
+        helper.getAsyncAttributeValue(pointFeatureLayer, 'data-geometry-type').then(function(value) {
             expect(value).toEqual('point');
         });
 
-        helper.getAsyncAttributeValue(featureLayer3, 'data-geometry-type').then(function(value) {
+        helper.getAsyncAttributeValue(polylineFeatureLayer, 'data-geometry-type').then(function(value) {
             expect(value).toEqual('polyline');
+        });
+        
+        helper.getAsyncAttributeValue(polygonFeatureLayer, 'data-geometry-type').then(function(value) {
+            expect(value).toEqual('polygon');
         });
     });
 
@@ -44,10 +44,10 @@ describe('Feature Layers', function() {
 
         showTreesToggle.click();
 
-        helper.getAsyncAttributeValue(featureLayer2, 'data-geometry-type').then(function() {
+        helper.getAsyncAttributeValue(pointFeatureLayer, 'data-geometry-type').then(function() {
             // we are not concerned with the data-geometry-type
             // but we want to give the layer time to display itself after executing showTreesToggle.click()
-            expect(featureLayer2.getCssValue('display')).toEqual('block');
+            expect(pointFeatureLayer.getCssValue('display')).toEqual('block');
         });
     });
 
@@ -59,8 +59,8 @@ describe('Feature Layers', function() {
         treesDefExpressionInputText.sendKeys('HEIGHT > 180');
         defExpressionSubmit.click();
 
-        var featureLayerChildImageNodes = featureLayer2.all(by.tagName('image'));
-        helper.getAsyncAttributeValue(featureLayer2, 'data-geometry-type').then(function() {
+        var featureLayerChildImageNodes = pointFeatureLayer.all(by.tagName('image'));
+        helper.getAsyncAttributeValue(pointFeatureLayer, 'data-geometry-type').then(function() {
             // we are not concerned with the data-geometry-type
             // but we want to give the layer time to display itself after submitting the def expression form
             expect(featureLayerChildImageNodes.count()).toEqual(2);
@@ -71,12 +71,12 @@ describe('Feature Layers', function() {
         // element locator(s) specific to this test
         var parksOpacityInputText = element(by.model('map.parksOpacity'));
 
-        var beforeOpacity = featureLayer1.getAttribute('opacity');
+        var beforeOpacity = polygonFeatureLayer.getAttribute('opacity');
         
         parksOpacityInputText.clear();
         parksOpacityInputText.sendKeys('0');
         
-        var afterOpacity = featureLayer1.getAttribute('opacity');
+        var afterOpacity = polygonFeatureLayer.getAttribute('opacity');
 
         expect(afterOpacity).not.toBe(beforeOpacity);
     });

--- a/test/feature-layers.html
+++ b/test/feature-layers.html
@@ -13,15 +13,9 @@
         <!-- add map to page and bind to scope map parameters -->
         <esri-map id="map" center="map.center" zoom="map.zoom" basemap="topo">
             <esri-feature-layer
-                url="http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Portland_Parks/FeatureServer/0"
-                opacity="{{map.parksOpacity}}"
-                >
-            </esri-feature-layer>
-            <esri-feature-layer
                 url="http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0"
                 visible="{{map.showTrees}}"
-                definition-expression="{{map.treesDefExpression}}"
-                >
+                definition-expression="{{map.treesDefExpression}}">
             </esri-feature-layer>
             <!-- a standalone definition-expression will take precedence over one provided within the layer-options -->
             <!-- see an example of this in the following <esri-feature-layer> -->
@@ -51,6 +45,10 @@
                     useMapTime: true,
                     visible: true
                 }">
+            </esri-feature-layer>
+            <esri-feature-layer
+                url="http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Portland_Parks/FeatureServer/0"
+                opacity="{{map.parksOpacity}}">
             </esri-feature-layer>
         </esri-map>
         <p><label><input type="checkbox" ng-model="map.showTrees" /> Show trees</label></p>


### PR DESCRIPTION
Please review. The primary changes here are to esriMap and esriFeatureLayer to work with the JSAPI map.addLayer optional `index` argument. The remaining changes are for relevant example and test pages, as well as updates to a readme snippet and the changelog.

Resolves #101.