### PR TITLE
controllerAs and bindToController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 [Upcoming changes][unreleased]
 
-None.
+Update map and layer directives to use controllerAs and bindToController instead of injecting $socpe into controllers. [#123](https://github.com/Esri/angular-esri-map/pull/123)
 
 ## [v1.0.0-beta.5]
 

--- a/src/directives/esriDynamicMapServiceLayer.js
+++ b/src/directives/esriDynamicMapServiceLayer.js
@@ -49,8 +49,12 @@
                 layerOptions: '&'
             },
 
+            controllerAs: 'vm',
+
+            bindToController: true,
+
             // define an interface for working with this directive
-            controller: function ($scope, $element, $attrs) {
+            controller: function () {
                 var self = this;
                 var layerDeferred = $q.defer();
 
@@ -94,19 +98,19 @@
                         }
                     }
 
-                    var layerOptions = $scope.layerOptions() || {};
+                    var layerOptions = self.layerOptions() || {};
 
                     // $scope.visible takes precedence over $scope.layerOptions.visible
-                    if (angular.isDefined($scope.visible)) {
-                        layerOptions.visible = isTrue($scope.visible);
+                    if (angular.isDefined(self.visible)) {
+                        layerOptions.visible = isTrue(self.visible);
                     }
 
                     // $scope.opacity takes precedence over $scope.layerOptions.opacity
-                    if ($scope.opacity) {
-                        layerOptions.opacity = Number($scope.opacity);
+                    if (self.opacity) {
+                        layerOptions.opacity = Number(self.opacity);
                     }
 
-                    // $scope.layerOptions.infoTemplates takes precedence over
+                    // self.layerOptions.infoTemplates takes precedence over
                     // layer options defined in nested esriLayerOption directives
                     if (angular.isObject(layerOptions.infoTemplates)) {
                         for (var layerIndex in layerOptions.infoTemplates) {
@@ -145,11 +149,11 @@
                     }
 
                     // create the layer object
-                    var layer = new ArcGISDynamicMapServiceLayer($attrs.url, layerOptions);
+                    var layer = new ArcGISDynamicMapServiceLayer(self.url, layerOptions);
 
                     // set visible layers if passed as attribute
-                    if ($scope.visibleLayers) {
-                        layer.setVisibleLayers(parseVisibleLayers($scope.visibleLayers));
+                    if (self.visibleLayers) {
+                        layer.setVisibleLayers(parseVisibleLayers(self.visibleLayers));
                     }
 
                     // resolve deferred w/ layer

--- a/src/directives/esriDynamicMapServiceLayer.js
+++ b/src/directives/esriDynamicMapServiceLayer.js
@@ -1,10 +1,6 @@
 (function (angular) {
     'use strict';
 
-    function isTrue(val) {
-        return val === true || val === 'true';
-    }
-
     // TODO: refactor to shared factory/service?
     function parseVisibleLayers(val) {
         var visibleLayers;
@@ -102,7 +98,7 @@
 
                     // $scope.visible takes precedence over $scope.layerOptions.visible
                     if (angular.isDefined(self.visible)) {
-                        layerOptions.visible = isTrue(self.visible);
+                        layerOptions.visible = esriMapUtils.isTrue(self.visible);
                     }
 
                     // $scope.opacity takes precedence over $scope.layerOptions.opacity
@@ -188,7 +184,7 @@
                 var mapController = controllers[1];
 
                 // bind directive attributes to layer properties and events
-                esriMapUtils.initLayerDirecive(scope, attrs, layerController, mapController);
+                esriMapUtils.initLayerDirective(scope, attrs, layerController, mapController);
             }
         };
     });

--- a/src/directives/esriFeatureLayer.js
+++ b/src/directives/esriFeatureLayer.js
@@ -1,10 +1,6 @@
 (function(angular) {
     'use strict';
 
-    // function isTrue(val) {
-    //     return val === true || val === 'true';
-    // }
-
     angular.module('esri.map').directive('esriFeatureLayer', function($q, esriMapUtils) {
         // this object will tell angular how our directive behaves
         return {
@@ -128,7 +124,7 @@
                 var mapController = controllers[1];
 
                 // bind directive attributes to layer properties and events
-                esriMapUtils.initLayerDirecive(scope, attrs, layerController, mapController).then(function(layer) {
+                esriMapUtils.initLayerDirective(scope, attrs, layerController, mapController).then(function(layer) {
 
                     // additional directive attribute binding specific to this type of layer
 

--- a/src/directives/esriFeatureLayer.js
+++ b/src/directives/esriFeatureLayer.js
@@ -1,9 +1,9 @@
 (function(angular) {
     'use strict';
 
-    function isTrue(val) {
-        return val === true || val === 'true';
-    }
+    // function isTrue(val) {
+    //     return val === true || val === 'true';
+    // }
 
     angular.module('esri.map').directive('esriFeatureLayer', function($q, esriMapUtils) {
         // this object will tell angular how our directive behaves
@@ -34,8 +34,12 @@
                 layerOptions: '&'
             },
 
+            controllerAs: 'vm',
+
+            bindToController: true,
+
             // define an interface for working with this directive
-            controller: function($scope) {
+            controller: function() {
                 var self = this;
                 var layerDeferred = $q.defer();
 
@@ -63,21 +67,22 @@
                         }
                     }
 
-                    var layerOptions = $scope.layerOptions() || {};
+                    // var layerOptions = $scope.layerOptions() || {};
+                    var layerOptions = self.layerOptions() || {};
 
                     // $scope.visible takes precedence over $scope.layerOptions.visible
-                    if (angular.isDefined($scope.visible)) {
-                        layerOptions.visible = isTrue($scope.visible);
+                    if (angular.isDefined(self.visible)) {
+                        layerOptions.visible = esriMapUtils.isTrue(self.visible);
                     }
 
                     // $scope.opacity takes precedence over $scope.layerOptions.opacity
-                    if ($scope.opacity) {
-                        layerOptions.opacity = Number($scope.opacity);
+                    if (self.opacity) {
+                        layerOptions.opacity = Number(self.opacity);
                     }
 
                     // $scope.definitionExpression takes precedence over $scope.layerOptions.definitionExpression
-                    if ($scope.definitionExpression) {
-                        layerOptions.definitionExpression = $scope.definitionExpression;
+                    if (self.definitionExpression) {
+                        layerOptions.definitionExpression = self.definitionExpression;
                     }
 
                     // $scope.layerOptions.infoTemplate takes precedence over
@@ -101,7 +106,8 @@
                         layerOptions.mode = FeatureLayer[layerOptions.mode];
                     }
 
-                    var layer = new FeatureLayer($scope.url, layerOptions);
+                    // var layer = new FeatureLayer($scope.url, layerOptions);
+                    var layer = new FeatureLayer(self.url, layerOptions);
                     layerDeferred.resolve(layer);
                 });
 
@@ -128,7 +134,7 @@
 
                     // watch the scope's definitionExpression property for changes
                     // set the definitionExpression of the feature layer
-                    scope.$watch('definitionExpression', function(newVal, oldVal) {
+                    scope.$watch('vm.definitionExpression', function(newVal, oldVal) {
                         if (newVal !== oldVal) {
                             layer.setDefinitionExpression(newVal);
                         }

--- a/src/directives/esriMap.js
+++ b/src/directives/esriMap.js
@@ -66,7 +66,7 @@
                             updateScopeFromMap(controller, map);
                             // make map object available to caller
                             // by calling the load event handler
-                            if (controller.load) {
+                            if (attrs.load) {
                                 controller.load()(map);
                             }
                         } else {
@@ -92,17 +92,17 @@
                         });
 
                         // listen for changes to scope.center and scope.zoom and update map
-                        scope.inUpdateCycle = false;
-                        if (!angular.isUndefined(controller.center) || !angular.isUndefined(controller.zoom)) {
+                        controller.inUpdateCycle = false;
+                        if (!angular.isUndefined(attrs.center) || !angular.isUndefined(attrs.zoom)) {
                             scope.$watchGroup(['mapCtrl.center.lng', 'mapCtrl.center.lat', 'mapCtrl.zoom'], function(newCenterZoom/*, oldCenterZoom*/) {
-                                if (scope.inUpdateCycle) {
+                                if (controller.inUpdateCycle) {
                                     return;
                                 }
                                 if (newCenterZoom[0] !== '' && newCenterZoom[1] !== '' && newCenterZoom[2] !== '') {
                                     // prevent circular updates between $watch and $apply
-                                    scope.inUpdateCycle = true;
+                                    controller.inUpdateCycle = true;
                                     map.centerAndZoom([newCenterZoom[0], newCenterZoom[1]], newCenterZoom[2]).then(function() {
-                                        scope.inUpdateCycle = false;
+                                        controller.inUpdateCycle = false;
                                     });
                                 }
                             });
@@ -116,16 +116,16 @@
                                 controller.extentChange()(e);
                             }
                             // prevent circular updates between $watch and $apply
-                            if (scope.inUpdateCycle) {
+                            if (controller.inUpdateCycle) {
                                 return;
                             }
-                            scope.inUpdateCycle = true;
+                            controller.inUpdateCycle = true;
                             scope.$apply(function() {
                                 // update scope properties
                                 updateScopeFromMap(controller, map);
                                 $timeout(function() {
                                     // this will be executed after the $digest cycle
-                                    scope.inUpdateCycle = false;
+                                    controller.inUpdateCycle = false;
                                 }, 0);
                             });
                         });
@@ -142,7 +142,7 @@
             },
 
             // directive api
-            controller: function(/*$scope, $element, */$attrs) {
+            controller: function($attrs) {
                 // get a reference to the controller
                 var self = this;
 

--- a/src/directives/esriMap.js
+++ b/src/directives/esriMap.js
@@ -16,6 +16,9 @@
             scope.zoom = map.getZoom();
         }
 
+        // handle to deregister the map if registered w/ esriRegistry
+        var deregister;
+
         return {
             // element only
             restrict: 'E',
@@ -38,8 +41,13 @@
                 mapOptions: '&'
             },
 
+            controllerAs: 'mapCtrl',
+
+            bindToController: true,
+
             // replace tag with div with same id
             compile: function($element, $attrs) {
+
                 // remove the id attribute from the main element
                 $element.removeAttr('id');
 
@@ -48,12 +56,93 @@
 
                 // since we are using compile we need to return our linker function
                 // the 'link' function handles how our directive responds to changes in $scope
-                /*jshint unused: false*/
-                return function(scope, element, attrs, controller) {};
+                return function(scope, element, attrs, controller) {
+
+                    controller.getMap().then(function(map) {
+                        if (map.loaded) {
+                            // map already loaded, we need to
+                            // update two-way bound scope properties
+                            // updateScopeFromMap(scope, map);
+                            updateScopeFromMap(controller, map);
+                            // make map object available to caller
+                            // by calling the load event handler
+                            if (controller.load) {
+                                controller.load()(map);
+                            }
+                        } else {
+                            // map is not yet loaded, this means that
+                            // two-way bound scope properties
+                            // will be updated by extent-change handler below
+                            // so don't need to update them here
+                            // just set up a handler for the map load event (if any)
+                            if (attrs.load) {
+                                map.on('load', function() {
+                                    scope.$apply(function() {
+                                        controller.load()(map);
+                                    });
+                                });
+                            }
+                        }
+
+                        // listen for changes to scope.basemap and update map
+                        scope.$watch('mapCtrl.basemap', function(newBasemap, oldBasemap) {
+                            if (map.loaded && newBasemap !== oldBasemap) {
+                                map.setBasemap(newBasemap);
+                            }
+                        });
+
+                        // listen for changes to scope.center and scope.zoom and update map
+                        scope.inUpdateCycle = false;
+                        if (!angular.isUndefined(controller.center) || !angular.isUndefined(controller.zoom)) {
+                            scope.$watchGroup(['mapCtrl.center.lng', 'mapCtrl.center.lat', 'mapCtrl.zoom'], function(newCenterZoom/*, oldCenterZoom*/) {
+                                if (scope.inUpdateCycle) {
+                                    return;
+                                }
+                                if (newCenterZoom[0] !== '' && newCenterZoom[1] !== '' && newCenterZoom[2] !== '') {
+                                    // prevent circular updates between $watch and $apply
+                                    scope.inUpdateCycle = true;
+                                    map.centerAndZoom([newCenterZoom[0], newCenterZoom[1]], newCenterZoom[2]).then(function() {
+                                        scope.inUpdateCycle = false;
+                                    });
+                                }
+                            });
+                        }
+
+                        // listen for changes to map extent and
+                        // call extent-change handler (if any)
+                        // also update scope.center and scope.zoom
+                        map.on('extent-change', function(e) {
+                            if (attrs.extentChange) {
+                                controller.extentChange()(e);
+                            }
+                            // prevent circular updates between $watch and $apply
+                            if (scope.inUpdateCycle) {
+                                return;
+                            }
+                            scope.inUpdateCycle = true;
+                            scope.$apply(function() {
+                                // update scope properties
+                                updateScopeFromMap(controller, map);
+                                $timeout(function() {
+                                    // this will be executed after the $digest cycle
+                                    scope.inUpdateCycle = false;
+                                }, 0);
+                            });
+                        });
+
+                        // clean up
+                        scope.$on('$destroy', function() {
+                            if (deregister) {
+                                deregister();
+                            }
+                            map.destroy();
+                        });
+                    });
+                };
             },
 
             // directive api
-            controller: function($scope, $element, $attrs) {
+            controller: function(/*$scope, $element, */$attrs) {
                 // get a reference to the controller
                 var self = this;
 
@@ -63,16 +152,13 @@
 
                 // add this map to the registry
                 if ($attrs.registerAs) {
-                    var deregister = esriRegistry._register($attrs.registerAs, mapDeferred);
-
-                    // remove this from the registry when the scope is destroyed
-                    $scope.$on('$destroy', deregister);
+                    deregister = esriRegistry._register($attrs.registerAs, mapDeferred);
                 }
 
                 require(['esri/map', 'esri/arcgis/utils', 'esri/geometry/Extent', 'esri/dijit/Popup'], function(Map, arcgisUtils, Extent, Popup) {
                     // setup our mapOptions based on object hash from attribute string
                     // or from scope object property
-                    var mapOptions = $scope.mapOptions() || {};
+                    var mapOptions = self.mapOptions() || {};
 
                     // construct optional Extent for mapOptions
                     if (mapOptions.hasOwnProperty('extent')) {
@@ -95,23 +181,23 @@
 
                     // check for 1 way bound properties (basemap)
                     // $scope.basemap takes precedence over $scope.mapOptions.basemap
-                    if ($scope.basemap) {
-                        mapOptions.basemap = $scope.basemap;
+                    if (self.basemap) {
+                        mapOptions.basemap = self.basemap;
                     }
 
                     // check for 2 way bound properties (center and zoom)
                     // $scope.center takes precedence over $scope.mapOptions.center
-                    if ($scope.center) {
-                        if ($scope.center.lng && $scope.center.lat) {
-                            mapOptions.center = [$scope.center.lng, $scope.center.lat];
+                    if (self.center) {
+                        if (self.center.lng && self.center.lat) {
+                            mapOptions.center = [self.center.lng, self.center.lat];
                         } else {
-                            mapOptions.center = $scope.center;
+                            mapOptions.center = self.center;
                         }
                     }
 
                     // $scope.zoom takes precedence over $scope.mapOptions.zoom
-                    if ($scope.zoom) {
-                        mapOptions.zoom = $scope.zoom;
+                    if (self.zoom) {
+                        mapOptions.zoom = self.zoom;
                     }
 
                     // initialize map and resolve the deferred
@@ -123,7 +209,7 @@
                             // update layer infos for legend
                             self.layerInfos = arcgisUtils.getLegendLayers(response);
                             // add item info to scope
-                            $scope.itemInfo = response.itemInfo;
+                            self.itemInfo = response.itemInfo;
                             // resolve the promise with the map
                             mapDeferred.resolve(response.map);
                         });
@@ -133,83 +219,6 @@
                         // resolve the promise with the map
                         mapDeferred.resolve(map);
                     }
-
-                    mapDeferred.promise.then(function(map) {
-                        if (map.loaded) {
-                            // map already loaded, we need to
-                            // update two-way bound scope properties
-                            updateScopeFromMap($scope, map);
-                            // make map object available to caller
-                            // by calling the load event handler
-                            if ($attrs.load) {
-                                $scope.load()(map);
-                            }
-                        } else {
-                            // map is not yet loaded, this means that
-                            // two-way bound scope properties
-                            // will be updated by extent-change handler below
-                            // so don't need to update them here
-                            // just set up a handler for the map load event (if any)
-                            if ($attrs.load) {
-                                map.on('load', function() {
-                                    $scope.$apply(function() {
-                                        $scope.load()(map);
-                                    });
-                                });
-                            }
-                        }
-
-                        // listen for changes to $scope.basemap and update map
-                        $scope.$watch('basemap', function(newBasemap, oldBasemap) {
-                            if (map.loaded && newBasemap !== oldBasemap) {
-                                map.setBasemap(newBasemap);
-                            }
-                        });
-
-                        // listen for changes to $scope.center and $scope.zoom and update map
-                        $scope.inUpdateCycle = false;
-                        if (!angular.isUndefined($scope.center) || !angular.isUndefined($scope.zoom)) {
-                            $scope.$watchGroup(['center.lng', 'center.lat', 'zoom'], function(newCenterZoom/*, oldCenterZoom*/) {
-                                if ($scope.inUpdateCycle) {
-                                    return;
-                                }
-                                if (newCenterZoom[0] !== '' && newCenterZoom[1] !== '' && newCenterZoom[2] !== '') {
-                                    // prevent circular updates between $watch and $apply
-                                    $scope.inUpdateCycle = true;
-                                    map.centerAndZoom([newCenterZoom[0], newCenterZoom[1]], newCenterZoom[2]).then(function() {
-                                        $scope.inUpdateCycle = false;
-                                    });
-                                }
-                            });
-                        }
-
-                        // listen for changes to map extent and
-                        // call extent-change handler (if any)
-                        // also update $scope.center and $scope.zoom
-                        map.on('extent-change', function(e) {
-                            if ($attrs.extentChange) {
-                                $scope.extentChange()(e);
-                            }
-                            // prevent circular updates between $watch and $apply
-                            if ($scope.inUpdateCycle) {
-                                return;
-                            }
-                            $scope.inUpdateCycle = true;
-                            $scope.$apply(function() {
-                                // update scope properties
-                                updateScopeFromMap($scope, map);
-                                $timeout(function() {
-                                    // this will be executed after the $digest cycle
-                                    $scope.inUpdateCycle = false;
-                                }, 0);
-                            });
-                        });
-
-                        // clean up
-                        $scope.$on('$destroy', function() {
-                            map.destroy();
-                        });
-                    });
                 });
 
                 // method returns the promise that will be resolved with the map

--- a/src/services/esriMapUtils.js
+++ b/src/services/esriMapUtils.js
@@ -3,13 +3,13 @@
 
   angular.module('esri.map').factory('esriMapUtils', function () {
 
-    // test if a string value (i.e. directive attribute value)
-    function isTrue(val) {
-        return val === true || val === 'true';
-    }
-
     // stateless utility service
     var service = {};
+
+    // test if a string value (i.e. directive attribute value)
+    service.isTrue = function (val) {
+        return val === true || val === 'true';
+    };
 
     // bind directive attributes to layer properties and events
     service.initLayerDirecive = function(scope, attrs, layerController, mapController) {
@@ -31,15 +31,15 @@
 
             // watch the scope's visible property for changes
             // set the visibility of the feature layer
-            scope.$watch('visible', function(newVal, oldVal) {
+            scope.$watch('vm.visible', function(newVal, oldVal) {
                 if (newVal !== oldVal) {
-                    layer.setVisibility(isTrue(newVal));
+                    layer.setVisibility(service.isTrue(newVal));
                 }
             });
 
             // watch the scope's opacity property for changes
             // set the opacity of the feature layer
-            scope.$watch('opacity', function(newVal, oldVal) {
+            scope.$watch('vm.opacity', function(newVal, oldVal) {
                 if (newVal !== oldVal) {
                     layer.setOpacity(Number(newVal));
                 }
@@ -50,13 +50,13 @@
                 if (layer.loaded) {
                     // layer is already loaded
                     // make layer object available to caller immediately
-                    scope.load()(layer);
+                    scope.vm.load()(layer);
                 } else {
                     // layer is not yet loaded
                     // wait for load event, and then make layer object available
                     layer.on('load', function() {
                         scope.$apply(function() {
-                            scope.load()(layer);
+                            scope.vm.load()(layer);
                         });
                     });
                 }
@@ -66,7 +66,7 @@
             if (attrs.updateEnd) {
                 layer.on('update-end', function(e) {
                     scope.$apply(function() {
-                        scope.updateEnd()(e);
+                        scope.vm.updateEnd()(e);
                     });
                 });
             }

--- a/src/services/esriMapUtils.js
+++ b/src/services/esriMapUtils.js
@@ -12,7 +12,7 @@
     };
 
     // bind directive attributes to layer properties and events
-    service.initLayerDirecive = function(scope, attrs, layerController, mapController) {
+    service.initLayerDirective = function(scope, attrs, layerController, mapController) {
         var layerIndex = layerController.layerType === 'FeatureLayer' ? 0 : undefined;
 
         return layerController.getLayer().then(function(layer) {


### PR DESCRIPTION
Update map and layer directives to use `controllerAs` and `bindToController` instead of injecting `$socpe` into controllers.

resolves #109
