### PR TITLE
other-esri-modules-docs-fix

### DIFF
--- a/docs/app/examples/other-esri-modules.html
+++ b/docs/app/examples/other-esri-modules.html
@@ -4,16 +4,16 @@
 </esri-map>
 <p>Select a shape then draw on map to add graphic</p>
 <div>
-    <button ng-click="activeTool = 'Point'">Point</button>
-    <button ng-click="activeTool = 'Multipoint'">Multipoint</button>
-    <button ng-click="activeTool = 'Line'">Line</button>
-    <button ng-click="activeTool = 'Polyline'">Polyline</button>
-    <button ng-click="activeTool = 'FreehandPolyline'">Freehand Polyline</button>
-    <button ng-click="activeTool = 'Triangle'">Triangle</button>
-    <button ng-click="activeTool = 'Extent'">Rectangle</button>
-    <button ng-click="activeTool = 'Circle'">Circle</button>
-    <button ng-click="activeTool = 'Ellipse'">Ellipse</button>
-    <button ng-click="activeTool = 'Polygon'">Polygon</button>
-    <button ng-click="activeTool = 'FreehandPolygon'">Freehand Polygon</button>
+    <button ng-click="activateDrawTool('Point')">Point</button>
+    <button ng-click="activateDrawTool('Multipoint')">Multipoint</button>
+    <button ng-click="activateDrawTool('Line')">Line</button>
+    <button ng-click="activateDrawTool('Polyline')">Polyline</button>
+    <button ng-click="activateDrawTool('FreehandPolyline')">Freehand Polyline</button>
+    <button ng-click="activateDrawTool('Triangle')">Triangle</button>
+    <button ng-click="activateDrawTool('Extent')">Rectangle</button>
+    <button ng-click="activateDrawTool('Circle')">Circle</button>
+    <button ng-click="activateDrawTool('Ellipse')">Ellipse</button>
+    <button ng-click="activateDrawTool('Polygon')">Polygon</button>
+    <button ng-click="activateDrawTool('FreehandPolygon')">Freehand Polygon</button>
 </div>
 <p>Based on <a href="https://developers.arcgis.com/javascript/jssamples/graphics_add.html">this sample.</a></p>

--- a/docs/app/examples/other-esri-modules.js
+++ b/docs/app/examples/other-esri-modules.js
@@ -63,13 +63,15 @@ angular.module('esri-map-docs')
                     });
 
                     // set the active tool once a button is clicked
-                    $scope.$watch('activeTool', function(newVal, oldVal) {
-                        // if (newVal !== oldVal) {
-                            var tool = newVal.toLowerCase();
-                            map.disableMapNavigation();
-                            tb.activate(tool);
-                        // }
+                    // apply this function binding to scope since it is outside of the digest cycle
+                    $scope.$apply(function() {
+                        $scope.activateDrawTool = activateDrawTool;
                     });
+                }
+
+                function activateDrawTool(tool) {
+                    map.disableMapNavigation();
+                    tb.activate(tool.toLowerCase());
                 }
 
                 function addGraphic(evt) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -25,6 +25,9 @@
         .map {
             margin-bottom: 10px;
         }
+        .map .tooltip {
+            opacity: 1;
+        }
         .tab-container {
             padding-top: 1em;
         }


### PR DESCRIPTION
@tomwayson please review.

I've been independently working with angular and the Esri Draw toolbar and recently noticed that applying an `opacity` rule for the draw mouse tooltip is necessary to show it on the map.  I've seen this both in this repo's docs gh-pages as well as in another app using angular material design.

I also went with button function binding so that the same tool can be activated back-to-back after a `draw-end`.

If you're good with these changes, feel free to go ahead and take care of this PR, or I can deal with it myself.

Reminder to us: please deploy to gh-pages as well.

Thanks!