### PR TITLE
Added Karma for unit testing

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -145,13 +145,18 @@ gulp.task('deploy-prod', ['build'], function () {
 gulp.task('karma-once', function(done) {
   new KarmaServer({
     configFile: __dirname + '/test/unit/karma.conf.js',
-    singleRun: true
+    singleRun: true,
+    // if phantom doesn't start, change this port
+    // there's always some live reload listening on 9876
+    // so we're defaulting to 6789
+    port: 6789,
+    browsers: ['PhantomJS']
   }, done).start();
 });
 
 gulp.task('karma', function(done) {
   new KarmaServer({
-    configFile: __dirname + '/test/unit/karma.conf.js',
+    configFile: __dirname + '/test/unit/karma.conf.js'
   }, done).start();
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,10 +14,12 @@ var gutil = require('gulp-util');
 var browserSync = require('browser-sync');
 var deploy = require('gulp-gh-pages');
 var angularProtractor = require('gulp-angular-protractor');
+var KarmaServer = require('karma').Server;
 
 // source directives and services
 var srcJsFiles = 'src/**/*.js';
 var siteJsFiles = 'site/app/**/*.js';
+var unitTestSpecFiles = 'test/unit/**/*.spec.js';
 
 // lint source javascript files
 gulp.task('lint', function() {
@@ -97,7 +99,7 @@ gulp.task('build', function(callback) {
 
 // serve site and tests on local web server
 // and reload anytime source code or site are modified
-gulp.task('serve', ['build'], function() {
+gulp.task('serve', ['karma-once', 'build'], function() {
   browserSync({
     server: {
       baseDir: ['site', 'test', 'ngdocs']
@@ -108,6 +110,7 @@ gulp.task('serve', ['build'], function() {
   });
 
   gulp.watch([srcJsFiles,'./site/**.*.html', siteJsFiles, './site/styles/*.css'], ['build', browserSync.reload ]);
+  gulp.watch([srcJsFiles, unitTestSpecFiles ], [ 'karma-once' ]);
 });
 
 // serve tests on local web server
@@ -139,7 +142,20 @@ gulp.task('deploy-prod', ['build'], function () {
     }));
 });
 
-gulp.task('test', ['serve-test'], function() {
+gulp.task('karma-once', function(done) {
+  new KarmaServer({
+    configFile: __dirname + '/test/unit/karma.conf.js',
+    singleRun: true
+  }, done).start();
+});
+
+gulp.task('karma', function(done) {
+  new KarmaServer({
+    configFile: __dirname + '/test/unit/karma.conf.js',
+  }, done).start();
+});
+
+gulp.task('test', ['karma-once', 'serve-test'], function() {
   return gulp.src(['./test/e2e/specs/*.js'])
     .pipe(angularProtractor({
       'configFile': 'test/e2e/conf.js',

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "main": "dist/angular-esri-map.js",
   "dependencies": {},
   "devDependencies": {
+    "angular": "^1.4.7",
+    "angular-mocks": "^1.4.7",
     "browser-sync": "~1.6.1",
+    "chai": "^3.4.1",
     "eslint": "^1.9.0",
     "gh-release": "^2.0.1",
     "gulp": "^3.8.9",
@@ -20,6 +23,12 @@
     "gulp-strip-debug": "~0.3.0",
     "gulp-uglify": "~0.3.0",
     "gulp-util": "~2.2.16",
+    "jasmine-core": "^2.3.4",
+    "karma": "^0.13.15",
+    "karma-chrome-launcher": "^0.2.1",
+    "karma-jasmine": "^0.3.6",
+    "karma-phantomjs-launcher": "^0.2.1",
+    "phantomjs": "^1.9.18",
     "protractor": "~2.2.0",
     "run-sequence": "~0.3.6"
   },

--- a/src/core/esriLayerUtils.js
+++ b/src/core/esriLayerUtils.js
@@ -46,20 +46,21 @@
                 var FeatureLayer = esriModules[0];
                 var InfoTemplate = esriModules[1];
 
-                // normalize info template defined in layerOptions.infoTemplate
-                // or nested esriLayerOption directive to be instance of esri/InfoTemplate
-                // and pass to layer constructor in layerOptions
-                if (layerOptions.infoTemplate) {
-                    layerOptions.infoTemplate = objectToInfoTemplate(layerOptions.infoTemplate, InfoTemplate);
-                }
+                if (layerOptions) {
+                    // normalize info template defined in layerOptions.infoTemplate
+                    // or nested esriLayerOption directive to be instance of esri/InfoTemplate
+                    // and pass to layer constructor in layerOptions
+                    if (layerOptions.infoTemplate) {
+                        layerOptions.infoTemplate = objectToInfoTemplate(layerOptions.infoTemplate, InfoTemplate);
+                    }
 
-                // layerOptions.mode expects a FeatureLayer constant name as a <String>
-                // https://developers.arcgis.com/javascript/jsapi/featurelayer-amd.html#constants
-                if (layerOptions.hasOwnProperty('mode')) {
-                    // look up and convert to the appropriate <Number> value
-                    layerOptions.mode = FeatureLayer[layerOptions.mode];
+                    // layerOptions.mode expects a FeatureLayer constant name as a <String>
+                    // https://developers.arcgis.com/javascript/jsapi/featurelayer-amd.html#constants
+                    if (layerOptions.hasOwnProperty('mode')) {
+                        // look up and convert to the appropriate <Number> value
+                        layerOptions.mode = FeatureLayer[layerOptions.mode];
+                    }
                 }
-
                 return new FeatureLayer(url, layerOptions);
             });
         };
@@ -72,30 +73,32 @@
                 var ImageParameters = esriModules[2];
                 var layer;
 
-                // normalize info templates defined in layerOptions.infoTemplates
-                // or nested esriLayerOption directives to be instances of esri/InfoTemplate
-                // and pass to layer constructor in layerOptions
-                if (layerOptions.infoTemplates) {
-                    for (var layerId in layerOptions.infoTemplates) {
-                        if (layerOptions.infoTemplates.hasOwnProperty(layerId)) {
-                            layerOptions.infoTemplates[layerId].infoTemplate = objectToInfoTemplate(layerOptions.infoTemplates[layerId].infoTemplate, InfoTemplate);
-                        }
-                    }
-                }
-
-                // check for imageParameters property and
-                // convert into ImageParameters() if needed
-                if (angular.isObject(layerOptions.imageParameters)) {
-                    if (layerOptions.imageParameters.declaredClass !== 'esri.layers.ImageParameters') {
-                        var imageParameters = new ImageParameters();
-                        for (var key in layerOptions.imageParameters) {
-                            if (layerOptions.imageParameters.hasOwnProperty(key)) {
-                                // TODO: may want to convert timeExent to new TimeExtent()
-                                // also not handling conversion for bbox, imageSpatialReference, nor layerTimeOptions
-                                imageParameters[key] = layerOptions.imageParameters[key];
+                if (layerOptions) {
+                    // normalize info templates defined in layerOptions.infoTemplates
+                    // or nested esriLayerOption directives to be instances of esri/InfoTemplate
+                    // and pass to layer constructor in layerOptions
+                    if (layerOptions.infoTemplates) {
+                        for (var layerId in layerOptions.infoTemplates) {
+                            if (layerOptions.infoTemplates.hasOwnProperty(layerId)) {
+                                layerOptions.infoTemplates[layerId].infoTemplate = objectToInfoTemplate(layerOptions.infoTemplates[layerId].infoTemplate, InfoTemplate);
                             }
                         }
-                        layerOptions.imageParameters = imageParameters;
+                    }
+
+                    // check for imageParameters property and
+                    // convert into ImageParameters() if needed
+                    if (angular.isObject(layerOptions.imageParameters)) {
+                        if (layerOptions.imageParameters.declaredClass !== 'esri.layers.ImageParameters') {
+                            var imageParameters = new ImageParameters();
+                            for (var key in layerOptions.imageParameters) {
+                                if (layerOptions.imageParameters.hasOwnProperty(key)) {
+                                    // TODO: may want to convert timeExent to new TimeExtent()
+                                    // also not handling conversion for bbox, imageSpatialReference, nor layerTimeOptions
+                                    imageParameters[key] = layerOptions.imageParameters[key];
+                                }
+                            }
+                            layerOptions.imageParameters = imageParameters;
+                        }
                     }
                 }
 

--- a/src/core/esriLayerUtils.js
+++ b/src/core/esriLayerUtils.js
@@ -1,6 +1,15 @@
 (function(angular) {
     'use strict';
 
+    /**
+     * @ngdoc service
+     * @name esri.core.factory:esriLayerUtils
+     *
+     * @description
+     * Functions to create instances of layers and related classes (such as InfoTemplate).
+     *
+     * @requires esri.core.factory:esriLoader
+     */
     angular.module('esri.core').factory('esriLayerUtils', function(esriLoader) {
 
         // parse array of visible layer ids from a string
@@ -40,7 +49,14 @@
         // stateless utility service
         var service = {};
 
-        // create a feature layer
+        /**
+         * @ngdoc function
+         * @name createFeatureLayer
+         * @methodOf esri.core.factory:esriLayerUtils
+         * @param {String} url The url of the map or feature service layer
+         * @param {Object=} options FeatureLayer options
+         * @returns {Promise} Returns a $q style promise resolved with an instance of {@link https://developers.arcgis.com/javascript/jsapi/featurelayer-amd.html#featurelayer1 FeatureLayer}
+         */
         service.createFeatureLayer = function(url, layerOptions) {
             return esriLoader.require(['esri/layers/FeatureLayer', 'esri/InfoTemplate']).then(function(esriModules) {
                 var FeatureLayer = esriModules[0];
@@ -65,7 +81,14 @@
             });
         };
 
-        // create a dynamic service layer
+        /**
+         * @ngdoc function
+         * @name createDynamicMapServiceLayer
+         * @methodOf esri.core.factory:esriLayerUtils
+         * @param {String} url The url of the map service
+         * @param {Object=} options ArcGISDynamicMapServiceLayer options
+         * @returns {Promise} Returns a $q style promise resolved with an instance of {@link https://developers.arcgis.com/javascript/jsapi/arcgisdynamicmapservicelayer-amd.html#arcgisdynamicmapservicelayer1 ArcGISDynamicMapServiceLayer}
+         */
         service.createDynamicMapServiceLayer = function(url, layerOptions, visibleLayers) {
             return esriLoader.require(['esri/layers/ArcGISDynamicMapServiceLayer', 'esri/InfoTemplate', 'esri/layers/ImageParameters']).then(function(esriModules) {
                 var ArcGISDynamicMapServiceLayer = esriModules[0];
@@ -115,6 +138,13 @@
         };
 
         // create an InfoTemplate object from JSON
+        /**
+         * @ngdoc function
+         * @name createInfoTemplate
+         * @methodOf esri.core.factory:esriLayerUtils
+         * @param {Object|Array} infoTemplate Either an array with `['title', 'content']` or an object with `{title: 'title', content: 'content'}`
+         * @returns {Promise} Returns a $q style promise resolved with an instance of {@link https://developers.arcgis.com/javascript/jsapi/infotemplate-amd.html InfoTemplate}
+         */
         service.createInfoTemplate = function(infoTemplate) {
             return esriLoader.require('esri/InfoTemplate').then(function(InfoTemplate) {
                 return objectToInfoTemplate(infoTemplate, InfoTemplate);

--- a/test/unit/.eslintrc
+++ b/test/unit/.eslintrc
@@ -1,0 +1,9 @@
+{
+  "env": {
+    "jasmine": true
+  },
+  "globals": {
+    "module": false,
+    "inject": false
+  }
+}

--- a/test/unit/core/esriLayerUtils.spec.js
+++ b/test/unit/core/esriLayerUtils.spec.js
@@ -1,0 +1,184 @@
+describe('esriLayerUtils', function() {
+
+    var esriLoader;
+    var esriLayerUtils;
+    beforeEach(module('esri.core'));
+    beforeEach(module(function($provide) {
+        esriLoader = {};
+        $provide.value('esriLoader', esriLoader);
+    }));
+    beforeEach(inject(function(_esriLayerUtils_) {
+        esriLayerUtils = _esriLayerUtils_;
+    }));
+
+    describe('createInfoTemplate', function() {
+        var InfoTemplate;
+
+        beforeEach(function(){
+            InfoTemplate = jasmine.createSpy();
+            esriLoader.require = function() {
+                return {
+                    then: function(callback) {
+                        callback(InfoTemplate);
+                    }
+                };
+            };
+        });
+
+        it('should create a new InfoTemplate from an object', function() {
+            esriLayerUtils.createInfoTemplate({
+                title: 'title',
+                content: 'content'
+            });
+            expect(InfoTemplate.calls.argsFor(0)).toEqual(['title', 'content']);
+        });
+
+        it('should create a new InfoTemplate from an array', function() {
+            esriLayerUtils.createInfoTemplate(['title', 'content']);
+            expect(InfoTemplate.calls.argsFor(0)).toEqual(['title', 'content']);
+        });
+
+        it('should not create a new InfoTemplate from an InfoTemplate', function() {
+            esriLayerUtils.createInfoTemplate({
+                declaredClass: 'esri.InfoTemplate'
+            });
+            expect(InfoTemplate.calls.any()).toEqual(false);
+        });
+    });
+
+    describe('createFeatureLayer', function() {
+        var FeatureLayer;
+        var InfoTemplate;
+
+        beforeEach(function(){
+            FeatureLayer = jasmine.createSpy();
+            FeatureLayer.MODE_SNAPSHOT = 3;
+            InfoTemplate = jasmine.createSpy();
+            esriLoader.require = function() {
+                return {
+                    then: function(callback) {
+                        callback([FeatureLayer, InfoTemplate]);
+                    }
+                };
+            };
+        });
+
+        it('should pass just url to layer constructor if no options', function() {
+            esriLayerUtils.createFeatureLayer('notARealUrl');
+            expect(FeatureLayer.calls.argsFor(0)).toEqual(['notARealUrl', undefined]);
+            expect(InfoTemplate.calls.count()).toEqual(0);
+        });
+
+        it('should pass url and options to layer constructor', function() {
+            var options = {
+                id: 'test'
+            };
+            esriLayerUtils.createFeatureLayer('notARealUrl', options);
+            expect(FeatureLayer.calls.argsFor(0)).toEqual(['notARealUrl', options]);
+            expect(InfoTemplate.calls.count()).toEqual(0);
+        });
+
+        it('should normalize mode option', function() {
+            var options = {
+                mode: 'MODE_SNAPSHOT'
+            };
+            esriLayerUtils.createFeatureLayer('notARealUrl', options);
+            expect(FeatureLayer.calls.argsFor(0)).toEqual(['notARealUrl', options]);
+            expect(options.mode).toEqual(3);
+            expect(InfoTemplate.calls.count()).toEqual(0);
+        });
+
+        it('should normalize infoTemplate option', function() {
+            var options = {
+                infoTemplate: ['title', 'content']
+            };
+            esriLayerUtils.createFeatureLayer('notARealUrl', options);
+            expect(FeatureLayer.calls.argsFor(0)).toEqual(['notARealUrl', options]);
+            expect(InfoTemplate.calls.argsFor(0)).toEqual(['title', 'content']);
+        });
+
+    });
+
+    describe('createDynamicMapServiceLayer', function() {
+        var ArcGISDynamicMapServiceLayer;
+        var InfoTemplate;
+        var ImageParameters;
+
+        beforeEach(function(){
+            ArcGISDynamicMapServiceLayer = jasmine.createSpy();
+            InfoTemplate = jasmine.createSpy();
+            ImageParameters = jasmine.createSpy();
+            // spyOn(ArcGISDynamicMapServiceLayer, 'setVisibleLayers');
+            esriLoader.require = function() {
+                return {
+                    then: function(callback) {
+                        callback([ArcGISDynamicMapServiceLayer, InfoTemplate, ImageParameters]);
+                    }
+                };
+            };
+        });
+
+        it('should pass just url to layer constructor if no options', function() {
+            esriLayerUtils.createDynamicMapServiceLayer('notARealUrl');
+            expect(ArcGISDynamicMapServiceLayer.calls.argsFor(0)).toEqual(['notARealUrl', undefined]);
+            expect(InfoTemplate.calls.count()).toEqual(0);
+            expect(ImageParameters.calls.count()).toEqual(0);
+        });
+
+        it('should pass url and options to layer constructor', function() {
+            var options = {
+                id: 'test'
+            };
+            esriLayerUtils.createDynamicMapServiceLayer('notARealUrl', options);
+            expect(ArcGISDynamicMapServiceLayer.calls.argsFor(0)).toEqual(['notARealUrl', options]);
+            expect(InfoTemplate.calls.count()).toEqual(0);
+            expect(ImageParameters.calls.count()).toEqual(0);
+        });
+
+        it('should normalize imageParameters option', function() {
+            var options = {
+                imageParameters: {
+                    format: 'jpeg'
+                }
+            };
+            esriLayerUtils.createDynamicMapServiceLayer('notARealUrl', options);
+            expect(ArcGISDynamicMapServiceLayer.calls.argsFor(0)).toEqual(['notARealUrl', options]);
+            expect(InfoTemplate.calls.count()).toEqual(0);
+            expect(ImageParameters.calls.count()).toEqual(1);
+        });
+
+        it('should normalize infoTemplates option', function() {
+            var options = {
+                infoTemplates: {
+                    1: {
+                        infoTemplate: {
+                            title: 'title1',
+                            content: 'content1'
+                        }
+                    },
+                    2: {
+                        infoTemplate: ['title2', 'content2']
+                    }
+                }
+            };
+            esriLayerUtils.createDynamicMapServiceLayer('notARealUrl', options);
+            expect(ArcGISDynamicMapServiceLayer.calls.argsFor(0)).toEqual(['notARealUrl', options]);
+            expect(InfoTemplate.calls.argsFor(0)).toEqual(['title1', 'content1']);
+            expect(InfoTemplate.calls.argsFor(1)).toEqual(['title2', 'content2']);
+            expect(ImageParameters.calls.count()).toEqual(0);
+        });
+
+        it('should set visibleLayers', function() {
+            // this feels dirty
+            ArcGISDynamicMapServiceLayer.prototype.setVisibleLayers = function(layers) {
+                expect(layers).toEqual([1,2]);
+            };
+            esriLayerUtils.createDynamicMapServiceLayer('notARealUrl', null, '1,2');
+            expect(ArcGISDynamicMapServiceLayer.calls.argsFor(0)).toEqual(['notARealUrl', null]);
+            expect(InfoTemplate.calls.count()).toEqual(0);
+            expect(ImageParameters.calls.count()).toEqual(0);
+        });
+
+    });
+
+});

--- a/test/unit/core/esriLoader.spec.js
+++ b/test/unit/core/esriLoader.spec.js
@@ -1,0 +1,17 @@
+describe('esriLoader', function() {
+
+    var esriLoader;
+    beforeEach(module('esri.core'));
+    beforeEach(inject(function(_$rootScope_, _$q_, _esriLoader_) {
+        esriLoader = _esriLoader_;
+    }));
+
+    describe('isLoaded', function() {
+
+        it('should not be loaded if script not added to page', function() {
+            expect(esriLoader.isLoaded()).toBe(false);
+        });
+
+    });
+
+});

--- a/test/unit/karma.conf.js
+++ b/test/unit/karma.conf.js
@@ -1,0 +1,73 @@
+// Karma configuration
+// http://karma-runner.github.io/0.12/config/configuration-file.html
+// Generated on 2015-11-11 using
+// generator-karma 1.0.0
+
+module.exports = function(config) {
+    'use strict';
+
+    config.set({
+        // enable / disable watching file and executing tests whenever any file changes
+        autoWatch: true,
+
+        // base path, that will be used to resolve files and exclude
+        basePath: '',
+
+        // testing framework to use (jasmine/mocha/qunit/...)
+        // as well as any additional frameworks (requirejs/chai/sinon/...)
+        frameworks: [
+            'jasmine'
+        ],
+
+        // list of files / patterns to load in the browser
+        files: [
+            '../../node_modules/angular/angular.js',
+            '../../node_modules/angular-mocks/angular-mocks.js',
+            '../../src/**/*.js',
+            '../../test/unit/**/*.spec.js'
+        ],
+
+        // list of files / patterns to exclude
+        exclude: [],
+
+        // web server port
+        port: 8080,
+
+        // Start these browsers, currently available:
+        // - Chrome
+        // - ChromeCanary
+        // - Firefox
+        // - Opera
+        // - Safari (only Mac)
+        // - PhantomJS
+        // - IE (only Windows)
+        browsers: [
+            // TODO: unable to get PhantomJS working for some reason
+            'Chrome'
+        ],
+
+        // Which plugins to enable
+        plugins: [
+            'karma-chrome-launcher',
+            'karma-phantomjs-launcher',
+            'karma-jasmine'
+        ],
+
+        // Continuous Integration mode
+        // if true, it capture browsers, run tests and exit
+        singleRun: false,
+
+        colors: true,
+
+        // level of logging
+        // possible values: LOG_DISABLE || LOG_ERROR || LOG_WARN || LOG_INFO || LOG_DEBUG
+        logLevel: config.LOG_INFO
+
+        // Uncomment the following lines if you are using grunt's server to run the tests
+        // proxies: {
+        //   '/': 'http://localhost:9000/'
+        // },
+        // URL root prevent conflicts with the site root
+        // urlRoot: '_karma_'
+    });
+};


### PR DESCRIPTION
I think the patterns I've set up in the esriLayerUtils spec will work well for most of the other services and controllers. It's not perfect, but it will serve as the foundation for writing other tests.

There's probably a more Angularish way to fake esriLoader's `require()` like [using ngMock's deferred](http://www.bradoncode.com/blog/2015/07/25/tip-unit-test-promise-angular/) rather than creating my own mock promise object), but that looks like a big hassle. I'm pretty sure we'll have to do something like that to test the functions in esriLoader - or maybe just spy on `window.require()`? I'm definitely open to suggestions here, but right now the tests are testing the right code, run fast, and are pretty easy to set up.

Also, w/ grunt, I'm used to [configuring karma's server to run in the background (i.e. as a child process) and having grunt's watch just re run the tests as needed](https://github.com/karma-runner/grunt-karma#karma-server-with-grunt-watch). I haven't figured out how to do this yet w/ gulp, so for now, gulp's watch starts/stops the karma server each time there's a change to the source or spec files. That can be refined later, maybe w/ the help of [karma-background](https://github.com/callmehiphop/karma-background/).

Resolves #30
(I feel like I should get a necromancer badge :skull: or something for that)
