### PR TITLE
api-docs-index

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -191,7 +191,10 @@ gulp.task('ngdocs', [], function () {
   var gulpDocs = require('gulp-ngdocs');
   return gulpDocs.sections({
       api: {
-        glob: ['src/**/*.js'],
+        glob: [
+          'src/**/*.js', // source files
+          'site/docs-resources/index.ngdoc' // documentation landing page
+        ],
         api: true,
         title: 'API'
       }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -109,8 +109,9 @@ gulp.task('serve', ['karma-once', 'build'], function() {
     notify: false
   });
 
-  gulp.watch([srcJsFiles,'./site/**.*.html', siteJsFiles, './site/styles/*.css'], ['build', browserSync.reload ]);
+  gulp.watch([srcJsFiles, './site/**.*.html', siteJsFiles, './site/styles/*.css'], ['build', browserSync.reload ]);
   gulp.watch([srcJsFiles, unitTestSpecFiles ], [ 'karma-once' ]);
+  gulp.watch(['./site/docs-resources/**'], ['ngdocs', browserSync.reload ]);
 });
 
 // serve tests on local web server
@@ -193,7 +194,7 @@ gulp.task('ngdocs', [], function () {
       api: {
         glob: [
           'src/**/*.js', // source files
-          'site/docs-resources/index.ngdoc' // documentation landing page
+          'site/docs-resources/**/*.ngdoc' // documentation landing page
         ],
         api: true,
         title: 'API'

--- a/site/app/home/home.html
+++ b/site/app/home/home.html
@@ -11,9 +11,9 @@
     </div>
     <div class="col-sm-4">
         <h2>
-            <a href="docs/#/api/esri.map.directive:esriMap">Documentation</a>
+            <a href="docs">Documentation</a>
         </h2>
-        <p>Learn the <a href="docs/#/api/esri.map.directive:esriMap">API</a> for the directives and services in depth.</p>
+        <p>Learn the <a href="docs">API</a> for the directives and services in depth.</p>
     </div>
     <div class="col-sm-4">
         <h2>

--- a/site/docs-resources/esri.core.ngdoc
+++ b/site/docs-resources/esri.core.ngdoc
@@ -1,0 +1,21 @@
+@ngdoc overview
+@id esri.core
+@name esri.core
+
+@description
+
+## `esri.core` Module
+
+The `esri.core` module includes services used by the directives in the {@link esri.map esri.map} module. These services can also be used directly by your own custom directives.
+
+### Loading Esri Modules
+
+Use {@link esri.core.factory:esriLoader esriLoader} to lazy load the Esri ArcGIS API or to load API modules.
+
+### Creating Map and Layer Instances
+
+Use the {@link esri.core.factory:esriMapUtils esriMapUtils} and {@link esri.core.factory:esriLayerUtils esriLayerUtils} services to help create instances of maps and layers.
+
+### Getting a Reference to the Map
+
+Use the {@link esri.core.factory:esriRegistry esriRegistry} to store and retrieve map instances for use in parent controllers.

--- a/site/docs-resources/esri.map.ngdoc
+++ b/site/docs-resources/esri.map.ngdoc
@@ -1,0 +1,17 @@
+@ngdoc overview
+@id esri.map
+@name esri.map
+
+@description
+
+## `esri.map` Module
+
+The `esri.map` module includes reusable directives for {@link esri.map.directive:esriMap maps}, {@link esri.map.directive:esriFeatureLayer layers}, and related UI elements such as {@link esri.map.directive:esriLegend legend} and {@link esri.map.directive:esriInfoTemplate info template}.
+
+### Working with Maps
+
+Use the {@link esri.map.directive:esriMap esriMap} directive allows you to place a map on the page. Use the {@link esri.map.directive:esriLegend esriLegend} directive to place show a legend for the map.
+
+### Adding Layers to a Map
+
+Use the {@link esri.map.directive:esriFeatureLayer esriFeatureLayer} and {@link esri.map.directive:esriDynamicMapServiceLayer esriDynamicMapServiceLayer} directives to add layers to a map. Use the {@link esri.map.directive:infoTemplate infoTemplate} directive to format layer pop ups.

--- a/site/docs-resources/index.ngdoc
+++ b/site/docs-resources/index.ngdoc
@@ -1,0 +1,7 @@
+@ngdoc overview
+@id index
+@name index
+
+@description
+
+## Documentation for angular-esri-map

--- a/site/docs-resources/index.ngdoc
+++ b/site/docs-resources/index.ngdoc
@@ -4,4 +4,12 @@
 
 @description
 
-## Documentation for angular-esri-map
+## API Documentation
+
+### `esri.map` Module
+
+The {@link esri.map esri.map} module includes reusable directives for {@link esri.map.directive:esriMap maps}, {@link esri.map.directive:esriFeatureLayer layers}, and related UI elements such as {@link esri.map.directive:esriLegend legend} and {@link esri.map.directive:esriInfoTemplate info template}.
+
+### `esri.core` Module
+
+The {@link esri.core esri.core} module includes services used by the directives in the {@link esri.map esri.map} module. These services can also be used directly by your own custom directives.

--- a/site/index.html
+++ b/site/index.html
@@ -59,7 +59,7 @@
                 </li>
                 <li role="presentation" ng-class="{ active: page === 'examples' }"><a ng-href="#/examples">Examples</a>
                 </li>
-                <li role="presentation"><a href="./docs/#/api/esri.map.directive:esriMap">API</a>
+                <li role="presentation"><a href="./docs">API</a>
                 </li>
                 <li role="presentation" ng-class="{ active: page === 'about' }"><a ng-href="#/about">About</a>
                 </li>

--- a/src/core/esri.core.module.js
+++ b/src/core/esri.core.module.js
@@ -1,11 +1,6 @@
 (function(angular) {
     'use strict';
-    
-    /* @ngdoc overview
-     * @name esri.core
-     * @description
-     * THE ESRI.CORE MODULE DESCRIPTION GOES HERE
-     */
+
     angular.module('esri.core', []);
 
 })(angular);

--- a/src/core/esri.core.module.js
+++ b/src/core/esri.core.module.js
@@ -1,7 +1,7 @@
 (function(angular) {
     'use strict';
     
-    /* @ngdoc object
+    /* @ngdoc overview
      * @name esri.core
      * @description
      * THE ESRI.CORE MODULE DESCRIPTION GOES HERE

--- a/src/esri.map.module.js
+++ b/src/esri.map.module.js
@@ -1,12 +1,6 @@
 (function(angular) {
     'use strict';
-    
-    /* @ngdoc overview
-     * @name esri.map
-     * @requires esri.core
-     * @description
-     * THE ESRI.MAP MODULE DESCRIPTION GOES HERE
-     */
+
     angular.module('esri.map', ['esri.core']);
 
 })(angular);

--- a/src/esri.map.module.js
+++ b/src/esri.map.module.js
@@ -1,7 +1,7 @@
 (function(angular) {
     'use strict';
     
-    /* @ngdoc object
+    /* @ngdoc overview
      * @name esri.map
      * @requires esri.core
      * @description


### PR DESCRIPTION
@tomwayson I figured out the magic combination to get an index landing page wired up with our api documentation.  Now we need to just figure out the content we want.  Thoughts?  Then, that resolves #153.  Still no dice on documenting **esri.map** or **esri.core** modules.