### PR TITLE
remove unnessary angular refs from service/controllers

### DIFF
--- a/src/core/esriLayerUtils.js
+++ b/src/core/esriLayerUtils.js
@@ -38,7 +38,7 @@
             } else {
                 // construct infoTemplate from object, using 2 args style:
                 //  https://developers.arcgis.com/javascript/jsapi/infotemplate-amd.html#infotemplate2
-                if (angular.isArray(infoTemplate) && infoTemplate.length === 2) {
+                if (infoTemplate instanceof Array && infoTemplate.length === 2) {
                     return new InfoTemplate(infoTemplate[0], infoTemplate[1]);
                 } else {
                     return new InfoTemplate(infoTemplate.title, infoTemplate.content);
@@ -112,7 +112,7 @@
 
                     // check for imageParameters property and
                     // convert into ImageParameters() if needed
-                    if (angular.isObject(layerOptions.imageParameters)) {
+                    if (typeof layerOptions.imageParameters === 'object') {
                         if (layerOptions.imageParameters.declaredClass !== 'esri.layers.ImageParameters') {
                             var imageParameters = new ImageParameters();
                             for (var key in layerOptions.imageParameters) {

--- a/src/core/esriLoader.js
+++ b/src/core/esriLoader.js
@@ -29,19 +29,19 @@
         function bootstrap(options) {
             var deferred = $q.defer();
 
+            // Default options object to empty hash
+            var opts = options || {};
+
             // Don't reload API if it is already loaded
             if (isLoaded()) {
                 deferred.reject('ESRI API is already loaded.');
                 return deferred.promise;
             }
 
-            // Default options object to empty hash
-            options = angular.isDefined(options) ? options : {};
-
             // Create Script Object to be loaded
             var script    = document.createElement('script');
             script.type   = 'text/javascript';
-            script.src    = options.url || 'http://js.arcgis.com/3.14compact';
+            script.src    = opts.url || 'http://js.arcgis.com/3.14compact';
 
             // Set onload callback to resolve promise
             script.onload = function() { deferred.resolve( window.require ); };
@@ -82,23 +82,23 @@
                 deferred.reject('Trying to call esriLoader.require(), but esri API has not been loaded yet. Run esriLoader.bootstrap() if you are lazy loading esri ArcGIS API.');
                 return deferred.promise;
             }
-            if (angular.isString(moduleName)) {
+            if (typeof moduleName === 'string') {
                 require([moduleName], function (module) {
 
                     // Check if callback exists, and execute if it does
-                    if ( callback && angular.isFunction(callback) ) {
+                    if (callback && typeof callback === 'function') {
                         callback(module);
                     }
                     deferred.resolve(module);
                 });
             }
-            else if (angular.isArray(moduleName)) {
+            else if (moduleName instanceof Array) {
                 require(moduleName, function () {
 
                     var args = Array.prototype.slice.call(arguments);
 
                     // callback check, sends modules loaded as arguments
-                    if ( callback && angular.isFunction(callback) ) {
+                    if (callback && typeof callback === 'function') {
                         callback.apply(this, args);
                     }
 

--- a/src/core/esriMapUtils.js
+++ b/src/core/esriMapUtils.js
@@ -12,6 +12,11 @@
      */
     angular.module('esri.core').factory('esriMapUtils', function($q, esriLoader) {
 
+        // check if a variable is an array
+        function isArray(v) {
+            return v instanceof Array;
+        }
+
         // construct Extent if object is not already an instance
         // e.g. if the controller or HTML view are only providing JSON
         function objectToExtent(extent, Extent) {
@@ -41,14 +46,14 @@
         service.addCustomBasemap = function(name, basemapDefinition) {
             return esriLoader.require('esri/basemaps').then(function(esriBasemaps) {
                 var baseMapLayers = basemapDefinition.baseMapLayers;
-                if (!angular.isArray(baseMapLayers) && angular.isArray(basemapDefinition.urls)) {
+                if (!isArray(baseMapLayers) && isArray(basemapDefinition.urls)) {
                     baseMapLayers = basemapDefinition.urls.map(function(url) {
                         return {
                             url: url
                         };
                     });
                 }
-                if (angular.isArray(baseMapLayers)) {
+                if (isArray(baseMapLayers)) {
                     esriBasemaps[name] = {
                         baseMapLayers: baseMapLayers,
                         thumbnailUrl: basemapDefinition.thumbnailUrl,

--- a/src/layers/EsriDynamicMapServiceLayerController.js
+++ b/src/layers/EsriDynamicMapServiceLayerController.js
@@ -49,7 +49,7 @@
                 return esriLayerUtils.createInfoTemplate(infoTemplate).then(function(infoTemplateObject) {
                     // check if layer has info templates defined
                     var infoTemplates = layer.infoTemplates;
-                    if (!angular.isObject(infoTemplates)) {
+                    if (!infoTemplates) {
                         // create a new info templates hash
                         infoTemplates = {};
                     }

--- a/src/layers/EsriLayerControllerBase.js
+++ b/src/layers/EsriLayerControllerBase.js
@@ -33,7 +33,7 @@
             var layerOptions = this.layerOptions() || {};
 
             // visible takes precedence over layerOptions.visible
-            if (angular.isDefined(this.visible)) {
+            if (typeof this.visible !== 'undefined') {
                 layerOptions.visible = isTrue(this.visible);
             }
 

--- a/src/map/EsriMapController.js
+++ b/src/map/EsriMapController.js
@@ -16,6 +16,11 @@
      */
     angular.module('esri.map').controller('EsriMapController', function EsriMapController($attrs, $timeout, esriMapUtils, esriRegistry) {
 
+        // check if a variable is undefined
+        function isUndefined(v) {
+            return typeof v === 'undefined';
+        }
+
         // update two-way bound scope properties based on map state
         function updateCenterAndZoom(scope, map) {
             var geoCenter = map.geographicExtent && map.geographicExtent.getCenter();
@@ -33,7 +38,7 @@
 
         // this deferred will be resolved with the map
         var mapPromise;
-        
+
         /**
          * @ngdoc function
          * @name getMapProperties
@@ -225,7 +230,7 @@
 
                 // listen for changes to scope.center and scope.zoom and update map
                 self.inUpdateCycle = false;
-                if (!angular.isUndefined(attrs.center) || !angular.isUndefined(attrs.zoom)) {
+                if (!isUndefined(attrs.center) || !isUndefined(attrs.zoom)) {
                     scope.$watchGroup(['mapCtrl.center.lng', 'mapCtrl.center.lat', 'mapCtrl.zoom'], function(newCenterZoom) {
                         if (self.inUpdateCycle) {
                             return;


### PR DESCRIPTION
in ES6 services and controllers will just be classes so
replace angular helper functions with vanilla JS

resolves #161 