### PR TITLE
site-styling

### DIFF
--- a/site/app/examples/add-remove-layers.html
+++ b/site/app/examples/add-remove-layers.html
@@ -1,10 +1,11 @@
 <h2>Add/Remove Layers</h2>
 <!-- add map to page -->
-<esri-map id="map" map-options="{
-                center: [-122.676207, 45.523452],
-                zoom: 12,
-                basemap: 'topo'
-            }">
+<esri-map id="map" 
+    map-options="{
+        center: [-122.676207, 45.523452],
+        zoom: 12,
+        basemap: 'topo'
+    }">
     <!-- watch list of selected layers and add/remove each to/from the map -->
     <esri-feature-layer ng-repeat="url in selectedLayers" url="{{url}}"></esri-feature-layer>
 </esri-map>

--- a/site/app/examples/custom-basemap.html
+++ b/site/app/examples/custom-basemap.html
@@ -1,10 +1,12 @@
 <h2>Custom Basemap</h2>
 <!-- add map to page and bind to scope map parameters -->
-<esri-map id="map" map-options="{
-  center: [-111.879655861, 40.571338776],
-  zoom: 13,
-  sliderStyle: 'small'
-}" register-as="delormeMap">
+<esri-map id="map" 
+    map-options="{
+        center: [-111.879655861, 40.571338776],
+        zoom: 13,
+        sliderStyle: 'small'
+    }"
+    register-as="delormeMap">
 </esri-map>
 <p>Based on the example in <a href="https://developers.arcgis.com/javascript/jsapi/esri.basemaps-amd.html">this API reference page</a>.</p>
 <p>Documentation:

--- a/site/app/examples/dynamic-map-service-layer.html
+++ b/site/app/examples/dynamic-map-service-layer.html
@@ -1,7 +1,7 @@
 <h2>Dynamic Map Service Layer</h2>
 <!-- add map to page and bind to scope map parameters -->
 <esri-map id="map" map-options="{ sliderOrientation : 'horizontal' }">
-    <esri-dynamic-map-service-layer url="http://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Population_World/MapServer" visible="{{dynamicLayer.visible}}" opacity="{{dynamicLayer.opacity}}" layer-options="{ imageParameters: { format: 'jpeg' } }" />
+    <esri-dynamic-map-service-layer url="http://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Population_World/MapServer" visible="{{dynamicLayer.visible}}" opacity="{{dynamicLayer.opacity}}" layer-options="{ imageParameters: { format: 'jpeg' } }" ></esri-dynamic-map-service-layer>
 </esri-map>
 <p><input type="checkbox" ng-model="dynamicLayer.visible" /> World Population - opacity: <input type="number" step="0.1" min="0" max="1" ng-model="dynamicLayer.opacity" /></p>
 <p>Based on <a href="https://developers.arcgis.com/javascript/jssamples/map_dynamic.html">this sample</a>.</p>

--- a/site/app/examples/dynamic-map-service-layers.html
+++ b/site/app/examples/dynamic-map-service-layers.html
@@ -5,7 +5,9 @@ as they are only evaluated in the map/layer constructors -->
 <esri-map id="map" map-options="::map.options" load="setInfoWindow">
     <!-- dynamic map service layer w/ inline url and options
     as well as info template defined in a directive -->
-    <esri-dynamic-map-service-layer url="http://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Petroleum/KGS_OilGasFields_Kansas/MapServer" layer-options="{ id: 'oilAndGasLayer', opacity: 0.75 }">
+    <esri-dynamic-map-service-layer 
+        url="http://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Petroleum/KGS_OilGasFields_Kansas/MapServer"
+        layer-options="{ id: 'oilAndGasLayer', opacity: 0.75 }">
         <esri-info-template layer-id="0" title="<b>Oil and Gas data</b>">
             ${FIELD_NAME} production field<br>
             <div class="demographicInfoContent">
@@ -15,7 +17,11 @@ as they are only evaluated in the map/layer constructors -->
         </esri-info-template>
     </esri-dynamic-map-service-layer>
     <!-- dynamic map service layer w/ url and options bound to scope properties -->
-    <esri-dynamic-map-service-layer url="{{ ::demographicsLayer.url }}" layer-options="::demographicsLayer.options" visible-layers="1,2" />
+    <esri-dynamic-map-service-layer 
+        url="{{ ::demographicsLayer.url }}"
+        layer-options="::demographicsLayer.options"
+        visible-layers="1,2">
+    </esri-dynamic-map-service-layer>
 </esri-map>
 <p>Based on <a href="https://developers.arcgis.com/javascript/jssamples/map_twodynamic.html">this sample</a></p>
 <p>Documentation:

--- a/site/app/examples/feature-layers.html
+++ b/site/app/examples/feature-layers.html
@@ -21,8 +21,8 @@
 
 <p><label><input type="checkbox" ng-model="map.showTrees" /> Show trees</label></p>
 <p><form ng-submit="submitTreesDefExpression()">
-  <input type="text" ng-model="treesDefExpressionInputText" />
-  <input type="submit" id="submit" value="Set trees definition expression" />
+    <input type="text" ng-model="treesDefExpressionInputText" />
+    <input type="submit" id="submit" value="Set trees definition expression" />
 </form></p>
 <p><label><input type="number" ng-model="map.parksOpacity" min="0" max="1" step="0.1"/> Set parks opacity</label></p>
 <p>Lat: {{ map.center.lat | number:3 }}, Lng: {{ map.center.lng | number:3 }}, Zoom: {{map.zoom}}</p>

--- a/site/app/examples/layer-events.html
+++ b/site/app/examples/layer-events.html
@@ -1,13 +1,19 @@
 <h2>Layer Events</h2>
 <!-- add map to page and bind to scope map parameters -->
 <esri-map id="map" center="map.center" zoom="map.zoom" basemap="topo">
-    <esri-feature-layer
+    <esri-feature-layer 
         url="http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0"
         visible="{{map.showTrees}}"
         load="treesLayerLoaded"
         update-end="treesLayerUpdateEnd">
     </esri-feature-layer>
-    <esri-dynamic-map-service-layer url="http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer" layer-options="{ id: 'demographicsLayer', opacity: 0.8, showAttribution: false }" visible-layers="1,2" load="demographicsLayerLoaded" update-end="demographicsLayerUpdateEnd" />
+    <esri-dynamic-map-service-layer 
+        url="http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer"
+        layer-options="{ id: 'demographicsLayer', opacity: 0.8, showAttribution: false }"
+        visible-layers="1,2"
+        load="demographicsLayerLoaded"
+        update-end="demographicsLayerUpdateEnd">
+    </esri-dynamic-map-service-layer>
 </esri-map>
 <p><label><input type="checkbox" ng-model="map.showTrees" /> Show trees</label></p>
 <div class="clearfix">

--- a/site/app/examples/map-events.html
+++ b/site/app/examples/map-events.html
@@ -4,7 +4,8 @@
 </esri-map>
 <p>The map is
     <strong ng-show="!map.loaded">not</strong>loaded.</p>
-<p>Extent: {{ map.extent.toJson() }}</p>
+<p>Extent:</p>
+<p class="break-word">{{ map.extent.toJson() }}</p>
 <p>Documentation:
     <a href="./docs/#/api/esri.map.directive:esriMap">esri-map</a>
 </p>

--- a/site/app/examples/no-basemap.html
+++ b/site/app/examples/no-basemap.html
@@ -2,12 +2,12 @@
 <h4>Providing an Optional Extent and Adding a Feature Layer</h4>
 <!-- add map to page and bind to scope map parameters -->
 <esri-map id="map" center="map.center" zoom="map.zoom" map-options="map.mapOptions" extent-change="extentChanged">
-  <esri-feature-layer title="States" url="http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3"></esri-feature-layer>
+    <esri-feature-layer title="States" url="http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3"></esri-feature-layer>
 </esri-map>
 
 <p>
-    <span style="float: left; margin-right: 15px;">Extent: </span>
-    <span style="float: right;"><pre style="display: inline-block;">{{ map.extent.toJson() | json }}</pre></span>
+    <span class="pull-left" style="margin-right: 15px;">Extent: </span>
+    <span class="pull-right"><pre style="display: inline-block; min-width: 290px;">{{ map.extent.toJson() | json }}</pre></span>
 </p>
 <p>Current Scale: {{ map.scale | number:0 }}</p>
 <p>Min Scale: {{ map.mapOptions.minScale | number:0 }}, Max Scale: {{ map.mapOptions.maxScale | number:0 }}</p>

--- a/site/index.html
+++ b/site/index.html
@@ -58,8 +58,8 @@
             <div ng-view="" ng-class="{'col-sm-9': leftNavShow}"></div>
 
             <!-- source code snippets -->
-            <div ng-controller="SnippetsCtrl"  style="display:none;" ng-style="{display: leftNavStyle}">
-                <ul ng-show="tabs" class="nav nav-tabs col-sm-9" ng-select ng-model="currentTab" select-class="{'active': $optSelected}">
+            <div ng-controller="SnippetsCtrl" class="col-sm-9" style="display:none;" ng-style="{display: leftNavStyle}">
+                <ul ng-show="tabs" class="nav nav-tabs" ng-select ng-model="currentTab" select-class="{'active': $optSelected}">
                     <li ng-repeat="tab in tabs" ng-select-option="tab">
                         <a href="">{{ tab }}</a>
                     </li>

--- a/site/styles/main.css
+++ b/site/styles/main.css
@@ -13,6 +13,10 @@
   background-color: inherit;
 }
 
+.break-word {
+  overflow-wrap: break-word;
+}
+
 /* Examples title and summary spacing */
 .marketing h4 + p {
   margin-bottom: 28px;
@@ -33,6 +37,9 @@
 /* highlightjs */
 .hljs.javascript,
 .hljs.xml {
+  display: inline-block;
+  overflow-x: auto;
+  white-space: pre;
   font-size: 13px;
   background-color: inherit; /* only use if syntax highlighting background is light gray or near white */
 }


### PR DESCRIPTION
@tomwayson please review and also update gh-pages.

I mainly tried to fix the code snippet placement (Firefox actually exposed a bootstrap grid class error on my part), and also made snippets overflow-x instead of wrapping formatted code.  Was hoping that would make the snippets a bit clearer to follow.  

Also noticed that IE11 doesn't like (or rather, let's be honest: cannot ever be capable of understanding) custom tags that close themselves, e.g. `<esri-feature-layer />`, so I added closing tags where necessary.

As a final misc. task, I just worked on trying to make some of the html spacing a little more consistent throughout the examples.

As usual, all of this is up for debate.  Thanks!