### PR TITLE
JSAPI 3.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 [Upcoming changes][unreleased]
 
+### Changed
+esriLoader defaults to loading JSAPI v3.15. Docs site uses JSAPI v3.15 and Angular v1.4.8. [#166](https://github.com/Esri/angular-esri-map/pull/166)
+
 ## [v1.0.0-rc.2]
 
 ### Changed
@@ -134,7 +137,7 @@ Published to NPM [#80](https://github.com/Esri/angular-esri-map/issues/80)
 ### Changed
 
 * Directives and services now support the following minimum dependency versions: JSAPI v3.11 and Angular v1.3.0. The test pages will be maintained at these versions.
-* Docs site uses JSAPI v.3.14 (#66) and Angular v1.4.4. https://github.com/Esri/angular-esri-map/pull/67
+* Docs site uses JSAPI v3.14 (#66) and Angular v1.4.4. https://github.com/Esri/angular-esri-map/pull/67
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Once you've added the module to your application, you can use the sample code be
         <meta name="viewport" content="initial-scale=1.0, user-scalable=no">
         <meta charset="utf-8">
 
-        <link rel="stylesheet" type="text/css" href="http://js.arcgis.com/3.14/esri/css/esri.css">
+        <link rel="stylesheet" type="text/css" href="http://js.arcgis.com/3.15/esri/css/esri.css">
     </head>
     <body ng-controller="MapController">
     <esri-map id="map" center="map.center" zoom="map.zoom" basemap="topo">
@@ -42,8 +42,8 @@ Once you've added the module to your application, you can use the sample code be
         <esri-feature-layer url="http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Portland_Parks/FeatureServer/0"></esri-feature-layer>
     </esri-map>
     <p>Lat: {{ map.center.lat | number:3 }}, Lng: {{ map.center.lng | number:3 }}, Zoom: {{map.zoom}}</p>
-        <script type="text/javascript" src="http://js.arcgis.com/3.14compact"></script>
-        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.4.4/angular.js"></script>
+        <script type="text/javascript" src="http://js.arcgis.com/3.15amd"></script>
+        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular.js"></script>
         <script src="path/to/angular-esri-map.js"></script>
         <script type="text/javascript">
             angular.module('esri-map-example', ['esri.map'])

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Once you've added the module to your application, you can use the sample code be
         <esri-feature-layer url="http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Portland_Parks/FeatureServer/0"></esri-feature-layer>
     </esri-map>
     <p>Lat: {{ map.center.lat | number:3 }}, Lng: {{ map.center.lng | number:3 }}, Zoom: {{map.zoom}}</p>
-        <script type="text/javascript" src="http://js.arcgis.com/3.15amd"></script>
+        <script type="text/javascript" src="http://js.arcgis.com/3.15compact"></script>
         <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular.js"></script>
         <script src="path/to/angular-esri-map.js"></script>
         <script type="text/javascript">

--- a/site/app/examples/set-basemap.html
+++ b/site/app/examples/set-basemap.html
@@ -11,6 +11,7 @@
         <option value="hybrid">Hybrid</option>
         <option value="oceans">Oceans</option>
         <option value="national-geographic">National Geographic</option>
+        <option value="terrain">Terrain</option>
         <option value="osm">Open Street Map</option>
     </select>
     Lat: {{ map.center.lat | number:3 }}, Lng: {{ map.center.lng | number:3 }}, Zoom: {{map.zoom}}

--- a/site/index.html
+++ b/site/index.html
@@ -40,7 +40,7 @@
 
         <!-- shared left nav controller for example toc page and individual example pages -->
         <div ng-controller="ExamplesLeftNavCtrl">
-            <div class="col-sm-3" ng-if="leftNavShow" style="display:none;" ng-style="{display: leftNavStyle}"> 
+            <div class="col-sm-3" ng-if="leftNavShow" style="display:none;" ng-style="{display: leftNavStyle}">
                 <div ng-repeat="(categoryKeyName, examplesArray) in examplePageCategories">
                     <h4 class="page-header list-group-category">{{categoryKeyName}}</h4>
                     <div class="list-group">
@@ -80,7 +80,7 @@
 
     <!-- load Esri JavaScript API -->
     <!-- NOTE: defer is only needed b/c of UMD blocks in highlight.min.js -->
-    <script defer type="text/javascript" src="http://js.arcgis.com/3.15amd"></script>
+    <script defer type="text/javascript" src="http://js.arcgis.com/3.15compact"></script>
 
     <!-- load Angular -->
     <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular.js"></script>

--- a/site/index.html
+++ b/site/index.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.9.1/styles/github.min.css">
 
     <!-- load Esri CSS -->
-    <link rel="stylesheet" type="text/css" href="http://js.arcgis.com/3.14/esri/css/esri.css">
+    <link rel="stylesheet" type="text/css" href="http://js.arcgis.com/3.15/esri/css/esri.css">
 
     <!-- load custom styles for this app -->
     <link rel="stylesheet" type="text/css" href="styles/main.css">
@@ -80,12 +80,12 @@
 
     <!-- load Esri JavaScript API -->
     <!-- NOTE: defer is only needed b/c of UMD blocks in highlight.min.js -->
-    <script defer type="text/javascript" src="http://js.arcgis.com/3.14compact"></script>
+    <script defer type="text/javascript" src="http://js.arcgis.com/3.15amd"></script>
 
     <!-- load Angular -->
-    <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.4.4/angular.js"></script>
-    <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.4/angular-route.js"></script>
-    <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.4.4/angular-sanitize.js"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular.js"></script>
+    <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular-route.js"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular-sanitize.js"></script>
 
     <!-- code snippet syntax highlighting -->
     <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.9.1/highlight.min.js"></script>

--- a/src/core/esriLoader.js
+++ b/src/core/esriLoader.js
@@ -21,8 +21,8 @@
          * @description
          * Loads the Esri ArcGIS API for JavaScript.
          *
-         * @param {Object=} options Send a list of options of how to load theEsri ArcGIS API for JavaScript.
-         *  Defaults to `{url: 'http://js.arcgis.com/3.14compact'}`
+         * @param {Object=} options Send a list of options of how to load the Esri ArcGIS API for JavaScript.
+         *  Defaults to `{url: 'http://js.arcgis.com/3.15amd'}`
          *
          * @return {Promise} Returns a $q style promise which is resolved once the ArcGIS API for JavaScript has been loaded.
          */
@@ -41,7 +41,7 @@
             // Create Script Object to be loaded
             var script    = document.createElement('script');
             script.type   = 'text/javascript';
-            script.src    = opts.url || 'http://js.arcgis.com/3.14compact';
+            script.src    = opts.url || 'http://js.arcgis.com/3.15amd';
 
             // Set onload callback to resolve promise
             script.onload = function() { deferred.resolve( window.require ); };

--- a/src/core/esriLoader.js
+++ b/src/core/esriLoader.js
@@ -22,7 +22,7 @@
          * Loads the Esri ArcGIS API for JavaScript.
          *
          * @param {Object=} options Send a list of options of how to load the Esri ArcGIS API for JavaScript.
-         *  Defaults to `{url: 'http://js.arcgis.com/3.15amd'}`
+         *  Defaults to `{url: 'http://js.arcgis.com/3.15compact'}`
          *
          * @return {Promise} Returns a $q style promise which is resolved once the ArcGIS API for JavaScript has been loaded.
          */
@@ -41,7 +41,7 @@
             // Create Script Object to be loaded
             var script    = document.createElement('script');
             script.type   = 'text/javascript';
-            script.src    = opts.url || 'http://js.arcgis.com/3.15amd';
+            script.src    = opts.url || 'http://js.arcgis.com/3.15compact';
 
             // Set onload callback to resolve promise
             script.onload = function() { deferred.resolve( window.require ); };

--- a/test/set-basemap.html
+++ b/test/set-basemap.html
@@ -16,7 +16,6 @@
         </esri-map>
         <p>Basemap: <select ng-model="map.basemap">
             <option value="gray">Gray</option>
-            <option value="dark-gray">Dark Gray</option>
             <option value="topo">Topographic</option>
             <option value="streets">Streets</option>
             <option value="satellite">Satellite</option>

--- a/test/unit/core/esriLoader.spec.js
+++ b/test/unit/core/esriLoader.spec.js
@@ -35,8 +35,8 @@ describe('esriLoader', function() {
             });
 
             describe('when not passing url in options', function() {
-                it('should default to 3.14compact', function() {
-                    var url = 'http://js.arcgis.com/3.14compact';
+                it('should default to 3.15amd', function() {
+                    var url = 'http://js.arcgis.com/3.15amd';
                     esriLoader.bootstrap();
                     expect(document.body.appendChild.calls.argsFor(0)[0].src).toEqual(url);
                 });
@@ -44,7 +44,7 @@ describe('esriLoader', function() {
 
             describe('when passing url in options', function() {
                 it('should have same url', function() {
-                    var url = 'http://js.arcgis.com/3.14';
+                    var url = 'http://js.arcgis.com/3.15amd';
                     esriLoader.bootstrap({
                         url: url
                     });

--- a/test/unit/core/esriLoader.spec.js
+++ b/test/unit/core/esriLoader.spec.js
@@ -35,8 +35,8 @@ describe('esriLoader', function() {
             });
 
             describe('when not passing url in options', function() {
-                it('should default to 3.15amd', function() {
-                    var url = 'http://js.arcgis.com/3.15amd';
+                it('should default to 3.15compact', function() {
+                    var url = 'http://js.arcgis.com/3.15compact';
                     esriLoader.bootstrap();
                     expect(document.body.appendChild.calls.argsFor(0)[0].src).toEqual(url);
                 });
@@ -44,7 +44,7 @@ describe('esriLoader', function() {
 
             describe('when passing url in options', function() {
                 it('should have same url', function() {
-                    var url = 'http://js.arcgis.com/3.15amd';
+                    var url = 'http://js.arcgis.com/3.14compact';
                     esriLoader.bootstrap({
                         url: url
                     });


### PR DESCRIPTION
@tomwayson please review.  Resolves #156.  A couple of notes:

- Seem to be some timing differences between `3.15amd` and `3.15compact`.  I'd recommend trying out both on the docs site and refreshing pages to see what you think.  How should we proceed with what **esriLoader** defaults to?

- My `gulp test` is hosed with running protractor tests.  My protractor, webdriver-manager, node, java, etc. deps seem to be fine and on my win PATH.  Have you seen this occurring on your end?  Right when `gulp-angular-protractor` is starting up.  So, I'm submitting this PR but I'd have felt more comfortable with my changes if I could have run this first.