### PR TITLE
play nice(r) w/ HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 [Upcoming changes][unreleased]
 
+## [v1.0.1]
+
+### Changed
+
+esriLoader defaults to loading JSAPI using the same protocol (HTTP or HTTPS) as the page. [#179](https://github.com/Esri/angular-esri-map/issues/179)
+
+### Documentation
+
+Use protocol agnostic links to resouces [#179](https://github.com/Esri/angular-esri-map/issues/179) [@JamesMilnerUK](https://github.com/JamesMilnerUK)
+
+### Tests
+
+Use protocol agnostic links to resouces in test pages [#179](https://github.com/Esri/angular-esri-map/issues/179)
+
 ## [v1.0.0]
 
 ### Changed
@@ -189,7 +203,8 @@ Thank you to @willisd2, @ScottONeal, @thinking-aloud, and @jwasil for their cont
 * Initial public release.
 * Includes directives for map, features layers, and legend and services to facilitate loading Esri modules and enabling controllers to reference the map object.
 
-[unreleased]: https://github.com/Esri/angular-esri-map/compare/v1.0.0...HEAD
+[unreleased]: https://github.com/Esri/angular-esri-map/compare/v1.0.1...HEAD
+[v1.0.1]: https://github.com/Esri/angular-esri-map/compare/v1.0.0...v1.0.1
 [v1.0.0]: https://github.com/Esri/angular-esri-map/compare/v1.0.0-rc.2...v1.0.0
 [v1.0.0-rc.2]: https://github.com/Esri/angular-esri-map/compare/v1.0.0-rc.1...v1.0.0-rc.2
 [v1.0.0-rc.1]: https://github.com/Esri/angular-esri-map/compare/v1.0.0-beta.5...v1.0.0-rc.1

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-esri-map",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "homepage": "https://github.com/Esri/angular-esri-map",
   "authors": [
     "Javier Abadía <javier.abadia@esri.es> (https://github.com/jabadia)",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -106,6 +106,7 @@ gulp.task('serve', ['karma-once', 'build'], function() {
     },
     open: true,
     port: 9002,
+    https: true,
     notify: false
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-esri-map",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A collection of directives to help you use Esri maps and services in your Angular applications",
   "main": "dist/angular-esri-map.js",
   "dependencies": {},

--- a/site/app/examples/add-remove-layers.js
+++ b/site/app/examples/add-remove-layers.js
@@ -6,11 +6,11 @@ angular.module('esri-map-docs')
         $scope.layers = [
             {
                 name: 'Heritage Trees',
-                url: 'http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0'
+                url: '//services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0'
             },
             {
                 name: 'Parks',
-                url: 'http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Portland_Parks/FeatureServer/0'
+                url: '//services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Portland_Parks/FeatureServer/0'
             }
         ];
 

--- a/site/app/examples/additional-map-options.html
+++ b/site/app/examples/additional-map-options.html
@@ -3,8 +3,8 @@
 <div class="row">
     <div class="col-xs-8 col-sm-9">
         <esri-map id="map" center="map.center" zoom="map.zoom" basemap="topo" map-options="map.mapOptions">
-            <esri-feature-layer title="Water Bodies" url="http://sampleserver3.arcgisonline.com/ArcGIS/rest/services/Hydrography/Watershed173811/MapServer/0"></esri-feature-layer>
-            <esri-feature-layer title="Rivers" url="http://sampleserver3.arcgisonline.com/ArcGIS/rest/services/Hydrography/Watershed173811/MapServer/1"></esri-feature-layer>
+            <esri-feature-layer title="Water Bodies" url="//sampleserver3.arcgisonline.com/ArcGIS/rest/services/Hydrography/Watershed173811/MapServer/0"></esri-feature-layer>
+            <esri-feature-layer title="Rivers" url="//sampleserver3.arcgisonline.com/ArcGIS/rest/services/Hydrography/Watershed173811/MapServer/1"></esri-feature-layer>
             <div esri-legend target-id="legend"></div>
         </esri-map>
         <p>Lat: {{ map.center.lat | number:3 }}, Lng: {{ map.center.lng | number:3 }}, Zoom: {{ map.zoom }}</p>

--- a/site/app/examples/custom-basemap.html
+++ b/site/app/examples/custom-basemap.html
@@ -1,6 +1,6 @@
 <h2>Custom Basemap</h2>
 <!-- add map to page and bind to scope map parameters -->
-<esri-map id="map" 
+<esri-map id="map"
     map-options="{
         center: [-111.879655861, 40.571338776],
         zoom: 13,

--- a/site/app/examples/custom-basemap.js
+++ b/site/app/examples/custom-basemap.js
@@ -6,9 +6,9 @@ angular.module('esri-map-docs')
         // that way we could just use the basemap name in either
         // the map directive's basemap or map-options attributes
         esriMapUtils.addCustomBasemap('delorme', {
-            urls: ['http://services.arcgisonline.com/ArcGIS/rest/services/Specialty/DeLorme_World_Base_Map/MapServer'],
+            urls: ['//services.arcgisonline.com/ArcGIS/rest/services/Specialty/DeLorme_World_Base_Map/MapServer'],
             title: 'DeLorme',
-            thumbnailUrl: 'http://servername.fqdn.suffix/images/thumbnail_2014-11-25_61051.png'
+            thumbnailUrl: '//servername.fqdn.suffix/images/thumbnail_2014-11-25_61051.png'
         }).then(function(esriBasemaps) {
             console.log(esriBasemaps);
             // because we are adding the basemap in the controller,

--- a/site/app/examples/dynamic-map-service-layer.html
+++ b/site/app/examples/dynamic-map-service-layer.html
@@ -1,7 +1,7 @@
 <h2>Dynamic Map Service Layer</h2>
 <!-- add map to page and bind to scope map parameters -->
 <esri-map id="map" map-options="{ sliderOrientation : 'horizontal' }">
-    <esri-dynamic-map-service-layer url="http://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Population_World/MapServer" visible="{{dynamicLayer.visible}}" opacity="{{dynamicLayer.opacity}}" layer-options="{ imageParameters: { format: 'jpeg' } }" ></esri-dynamic-map-service-layer>
+    <esri-dynamic-map-service-layer url="//sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Population_World/MapServer" visible="{{dynamicLayer.visible}}" opacity="{{dynamicLayer.opacity}}" layer-options="{ imageParameters: { format: 'jpeg' } }" ></esri-dynamic-map-service-layer>
 </esri-map>
 <p><input type="checkbox" ng-model="dynamicLayer.visible" /> World Population - opacity: <input type="number" step="0.1" min="0" max="1" ng-model="dynamicLayer.opacity" /></p>
 <p>Based on <a href="https://developers.arcgis.com/javascript/jssamples/map_dynamic.html">this sample</a>.</p>

--- a/site/app/examples/dynamic-map-service-layers.html
+++ b/site/app/examples/dynamic-map-service-layers.html
@@ -5,8 +5,8 @@ as they are only evaluated in the map/layer constructors -->
 <esri-map id="map" map-options="::map.options" load="setInfoWindow">
     <!-- dynamic map service layer w/ inline url and options
     as well as info template defined in a directive -->
-    <esri-dynamic-map-service-layer 
-        url="http://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Petroleum/KGS_OilGasFields_Kansas/MapServer"
+    <esri-dynamic-map-service-layer
+        url="//sampleserver1.arcgisonline.com/ArcGIS/rest/services/Petroleum/KGS_OilGasFields_Kansas/MapServer"
         layer-options="{ id: 'oilAndGasLayer', opacity: 0.75 }">
         <esri-info-template layer-id="0" title="<b>Oil and Gas data</b>">
             ${FIELD_NAME} production field<br>
@@ -17,7 +17,7 @@ as they are only evaluated in the map/layer constructors -->
         </esri-info-template>
     </esri-dynamic-map-service-layer>
     <!-- dynamic map service layer w/ url and options bound to scope properties -->
-    <esri-dynamic-map-service-layer 
+    <esri-dynamic-map-service-layer
         url="{{ ::demographicsLayer.url }}"
         layer-options="::demographicsLayer.options"
         visible-layers="1,2">

--- a/site/app/examples/dynamic-map-service-layers.html
+++ b/site/app/examples/dynamic-map-service-layers.html
@@ -5,7 +5,7 @@ as they are only evaluated in the map/layer constructors -->
 <esri-map id="map" map-options="::map.options" load="setInfoWindow">
     <!-- dynamic map service layer w/ inline url and options
     as well as info template defined in a directive -->
-    <esri-dynamic-map-service-layer
+    <esri-dynamic-map-service-layer 
         url="//sampleserver1.arcgisonline.com/ArcGIS/rest/services/Petroleum/KGS_OilGasFields_Kansas/MapServer"
         layer-options="{ id: 'oilAndGasLayer', opacity: 0.75 }">
         <esri-info-template layer-id="0" title="<b>Oil and Gas data</b>">
@@ -17,7 +17,7 @@ as they are only evaluated in the map/layer constructors -->
         </esri-info-template>
     </esri-dynamic-map-service-layer>
     <!-- dynamic map service layer w/ url and options bound to scope properties -->
-    <esri-dynamic-map-service-layer
+    <esri-dynamic-map-service-layer 
         url="{{ ::demographicsLayer.url }}"
         layer-options="::demographicsLayer.options"
         visible-layers="1,2">

--- a/site/app/examples/dynamic-map-service-layers.js
+++ b/site/app/examples/dynamic-map-service-layers.js
@@ -25,7 +25,7 @@ angular.module('esri-map-docs')
         };
 
         $scope.demographicsLayer = {
-            url: 'http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer',
+            url: '//sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer',
             options: {
                 id: 'demographicsLayer',
                 opacity: 0.8,

--- a/site/app/examples/feature-layers.html
+++ b/site/app/examples/feature-layers.html
@@ -2,19 +2,19 @@
 <!-- add map to page and bind to scope map parameters -->
 <esri-map id="map" center="map.center" zoom="map.zoom" basemap="topo">
     <!-- a feature layer with optional visible and definition-expression attributes -->
-    <esri-feature-layer 
-        url="http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0"
-        visible="{{map.showTrees}}" 
+    <esri-feature-layer
+        url="//services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0"
+        visible="{{map.showTrees}}"
         definition-expression="{{map.treesDefExpression}}">
     </esri-feature-layer>
     <!-- a feature layer with an optional layer-options attribute -->
-    <esri-feature-layer 
-        url="http://services.arcgis.com/rOo16HdIMeOBI4Mb/ArcGIS/rest/services/Portland_Light_Rail_Lines/FeatureServer/0"
+    <esri-feature-layer
+        url="//services.arcgis.com/rOo16HdIMeOBI4Mb/ArcGIS/rest/services/Portland_Light_Rail_Lines/FeatureServer/0"
         layer-options="map.railLayerOptions">
     </esri-feature-layer>
     <!-- a feature layer with an optional opacity attribute -->
-    <esri-feature-layer 
-        url="http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Portland_Parks/FeatureServer/0"
+    <esri-feature-layer
+        url="//services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Portland_Parks/FeatureServer/0"
         opacity="{{map.parksOpacity}}">
     </esri-feature-layer>
 </esri-map>
@@ -33,7 +33,7 @@
     <p>If <code>visible</code>, <code>opacity</code>, or <code>definition-expression</code> are provided as standalone optional properties, they will override those same properties in the additional layer options.</p>
 </div>
 
-<p>Based on <a href="http://jsfiddle.net/patrickarlt/xy3nm1sq/1/">this JS Fiddle</a>.</p>
+<p>Based on <a href="https://jsfiddle.net/patrickarlt/xy3nm1sq/1/">this JS Fiddle</a>.</p>
 <p>Documentation:
     <a href="./docs/#/api/esri.map.directive:esriFeatureLayer">esri-feature-layer</a>,
     <a href="./docs/#/api/esri.map.directive:esriMap">esri-map</a>

--- a/site/app/examples/feature-layers.html
+++ b/site/app/examples/feature-layers.html
@@ -2,18 +2,18 @@
 <!-- add map to page and bind to scope map parameters -->
 <esri-map id="map" center="map.center" zoom="map.zoom" basemap="topo">
     <!-- a feature layer with optional visible and definition-expression attributes -->
-    <esri-feature-layer
+    <esri-feature-layer 
         url="//services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0"
         visible="{{map.showTrees}}"
         definition-expression="{{map.treesDefExpression}}">
     </esri-feature-layer>
     <!-- a feature layer with an optional layer-options attribute -->
-    <esri-feature-layer
+    <esri-feature-layer 
         url="//services.arcgis.com/rOo16HdIMeOBI4Mb/ArcGIS/rest/services/Portland_Light_Rail_Lines/FeatureServer/0"
         layer-options="map.railLayerOptions">
     </esri-feature-layer>
     <!-- a feature layer with an optional opacity attribute -->
-    <esri-feature-layer
+    <esri-feature-layer 
         url="//services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Portland_Parks/FeatureServer/0"
         opacity="{{map.parksOpacity}}">
     </esri-feature-layer>

--- a/site/app/examples/layer-events.html
+++ b/site/app/examples/layer-events.html
@@ -2,13 +2,13 @@
 <!-- add map to page and bind to scope map parameters -->
 <esri-map id="map" center="map.center" zoom="map.zoom" basemap="topo">
     <esri-feature-layer 
-        url="http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0"
+        url="//services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0"
         visible="{{map.showTrees}}"
         load="treesLayerLoaded"
         update-end="treesLayerUpdateEnd">
     </esri-feature-layer>
     <esri-dynamic-map-service-layer 
-        url="http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer"
+        url="//sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer"
         layer-options="{ id: 'demographicsLayer', opacity: 0.8, showAttribution: false }"
         visible-layers="1,2"
         load="demographicsLayerLoaded"

--- a/site/app/examples/legend.html
+++ b/site/app/examples/legend.html
@@ -3,8 +3,8 @@
 <div class="row">
     <div class="col-xs-8 col-sm-9">
         <esri-map id="map" center="map.center" zoom="map.zoom" basemap="topo" style="width: 100%">
-            <esri-feature-layer title="Water Bodies" url="http://sampleserver3.arcgisonline.com/ArcGIS/rest/services/Hydrography/Watershed173811/MapServer/0"></esri-feature-layer>
-            <esri-feature-layer title="Rivers" url="http://sampleserver3.arcgisonline.com/ArcGIS/rest/services/Hydrography/Watershed173811/MapServer/1"></esri-feature-layer>
+            <esri-feature-layer title="Water Bodies" url="//sampleserver3.arcgisonline.com/ArcGIS/rest/services/Hydrography/Watershed173811/MapServer/0"></esri-feature-layer>
+            <esri-feature-layer title="Rivers" url="//sampleserver3.arcgisonline.com/ArcGIS/rest/services/Hydrography/Watershed173811/MapServer/1"></esri-feature-layer>
             <div esri-legend target-id="legend"></div>
         </esri-map>
         <p>Lat: {{ map.center.lat | number:3 }}, Lng: {{ map.center.lng | number:3 }}, Zoom: {{map.zoom}}</p>

--- a/site/app/examples/no-basemap.html
+++ b/site/app/examples/no-basemap.html
@@ -2,7 +2,7 @@
 <h4>Providing an Optional Extent and Adding a Feature Layer</h4>
 <!-- add map to page and bind to scope map parameters -->
 <esri-map id="map" center="map.center" zoom="map.zoom" map-options="map.mapOptions" extent-change="extentChanged">
-    <esri-feature-layer title="States" url="http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3"></esri-feature-layer>
+    <esri-feature-layer title="States" url="//sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3"></esri-feature-layer>
 </esri-map>
 
 <p>
@@ -11,8 +11,8 @@
 </p>
 <p>Current Scale: {{ map.scale | number:0 }}</p>
 <p>Min Scale: {{ map.mapOptions.minScale | number:0 }}, Max Scale: {{ map.mapOptions.maxScale | number:0 }}</p>
-<p>Slider Orientation: {{ map.mapOptions.sliderOrientation }}, 
-Slider Position: {{ map.mapOptions.sliderPosition }}, 
+<p>Slider Orientation: {{ map.mapOptions.sliderOrientation }},
+Slider Position: {{ map.mapOptions.sliderPosition }},
 Display Graphics on Pan: {{ map.mapOptions.displayGraphicsOnPan }}</p>
 
 <p>Inspired by <a href="https://developers.arcgis.com/javascript/jssamples/fl_any_projection.html">this sample</a>.</p>

--- a/site/app/examples/other-esri-modules.js
+++ b/site/app/examples/other-esri-modules.js
@@ -24,7 +24,7 @@ angular.module('esri-map-docs')
 
                 var tb;
 
-                // markerSymbol is used for point and multipoint, see http://raphaeljs.com/icons/#talkq for more examples
+                // markerSymbol is used for point and multipoint, see //raphaeljs.com/icons/#talkq for more examples
                 var markerSymbol = new SimpleMarkerSymbol();
                 markerSymbol.setPath('M16,4.938c-7.732,0-14,4.701-14,10.5c0,1.981,0.741,3.833,2.016,5.414L2,25.272l5.613-1.44c2.339,1.316,5.237,2.106,8.387,2.106c7.732,0,14-4.701,14-10.5S23.732,4.938,16,4.938zM16.868,21.375h-1.969v-1.889h1.969V21.375zM16.772,18.094h-1.777l-0.176-8.083h2.113L16.772,18.094z');
                 markerSymbol.setColor(new Color('#00FFFF'));
@@ -41,7 +41,7 @@ angular.module('esri-map-docs')
                 // the images folder contains additional fill images, other options: sand.png, swamp.png or stiple.png
                 var fillSymbol = new PictureFillSymbol(
                     // 'images/mangrove.png',
-                    'http://developers.arcgis.com/javascript/samples/graphics_add/images/mangrove.png',
+                    '//developers.arcgis.com/javascript/samples/graphics_add/images/mangrove.png',
                     new SimpleLineSymbol(
                         SimpleLineSymbol.STYLE_SOLID,
                         new Color('#000'),

--- a/src/core/esriLoader.js
+++ b/src/core/esriLoader.js
@@ -41,7 +41,7 @@
             // Create Script Object to be loaded
             var script    = document.createElement('script');
             script.type   = 'text/javascript';
-            script.src    = opts.url || 'http://js.arcgis.com/3.15compact';
+            script.src    = opts.url || window.location.protocol + '//js.arcgis.com/3.15compact';
 
             // Set onload callback to resolve promise
             script.onload = function() { deferred.resolve( window.require ); };

--- a/test/add-remove-layers.html
+++ b/test/add-remove-layers.html
@@ -6,7 +6,7 @@
         <title>Add/Remove Layers</title>
 
         <!-- load Esri CSS -->
-        <link rel="stylesheet" type="text/css" href="http://js.arcgis.com/3.11/esri/css/esri.css">
+        <link rel="stylesheet" type="text/css" href="//js.arcgis.com/3.11/esri/css/esri.css">
     </head>
     <body ng-controller="MapController">
         <h2>Add/Remove Layers</h2>
@@ -24,9 +24,9 @@
             <input type="checkbox" ng-model="selected" ng-change="toggleLayer(layer.url)" /> {{layer.name}} <br />
         </div>
         <!-- load Esri JavaScript API -->
-        <script type="text/javascript" src="http://js.arcgis.com/3.11compact"></script>
+        <script type="text/javascript" src="//js.arcgis.com/3.11compact"></script>
         <!-- load Angular -->
-        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
         <!-- load angular-esri-map directives -->
         <script src="lib/angular-esri-map.js"></script>
         <!-- run example app controller -->
@@ -38,11 +38,11 @@
                     $scope.layers = [
                         {
                             name: 'Heritage Trees',
-                            url: 'http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0'
+                            url: '//services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0'
                         },
                         {
                             name: 'Parks',
-                            url: 'http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Portland_Parks/FeatureServer/0'
+                            url: '//services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Portland_Parks/FeatureServer/0'
                         }
                     ];
 

--- a/test/additional-map-options.html
+++ b/test/additional-map-options.html
@@ -6,7 +6,7 @@
         <title>Additional Map Options</title>
 
         <!-- load Esri CSS -->
-        <link rel="stylesheet" type="text/css" href="http://js.arcgis.com/3.11/esri/css/esri.css">
+        <link rel="stylesheet" type="text/css" href="//js.arcgis.com/3.11/esri/css/esri.css">
     </head>
     <body ng-controller="MapController">
         <h2>Additional Map Options</h2>
@@ -45,10 +45,10 @@
             </p>
         </div>
         <!-- load Esri JavaScript API -->
-        <script type="text/javascript" src="http://js.arcgis.com/3.11compact"></script>
+        <script type="text/javascript" src="//js.arcgis.com/3.11compact"></script>
         <!-- load Angular -->
-        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
-        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular-sanitize.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular-sanitize.js"></script>
         <!-- load angular-esri-map directives -->
         <script src="lib/angular-esri-map.js"></script>
         <!-- run example app controller -->

--- a/test/custom-basemap.html
+++ b/test/custom-basemap.html
@@ -6,7 +6,7 @@
         <title>Custom Basemap</title>
 
         <!-- load Esri CSS -->
-        <link rel="stylesheet" type="text/css" href="http://js.arcgis.com/3.13/esri/css/esri.css">
+        <link rel="stylesheet" type="text/css" href="//js.arcgis.com/3.13/esri/css/esri.css">
     </head>
     <body ng-controller="MapController">
         <h2>Custom Basemap</h2>
@@ -19,9 +19,9 @@
         </esri-map>
         <p>Based on the example in <a href="https://developers.arcgis.com/javascript/jsapi/esri.basemaps-amd.html">this API reference page</a>.</p>
         <!-- load Esri JavaScript API -->
-        <script type="text/javascript" src="http://js.arcgis.com/3.13compact"></script>
+        <script type="text/javascript" src="//js.arcgis.com/3.13compact"></script>
         <!-- load Angular -->
-        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.min.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.min.js"></script>
         <!-- load angular-esri-map directives -->
         <script src="lib/angular-esri-map.js"></script>
         <!-- run example app controller -->
@@ -32,9 +32,9 @@
                     // add "delorme" basemap
                     // NOTE: it would be best to do this in a route's resolve
                     esriMapUtils.addCustomBasemap('delorme', {
-                        urls: ['http://services.arcgisonline.com/ArcGIS/rest/services/Specialty/DeLorme_World_Base_Map/MapServer'],
+                        urls: ['//services.arcgisonline.com/ArcGIS/rest/services/Specialty/DeLorme_World_Base_Map/MapServer'],
                         title: 'DeLorme',
-                        thumbnailUrl: 'http://servername.fqdn.suffix/images/thumbnail_2014-11-25_61051.png'
+                        thumbnailUrl: '//servername.fqdn.suffix/images/thumbnail_2014-11-25_61051.png'
                     }).then(function(esriBasemaps) {
                         console.log(esriBasemaps);
                         // esri registry is only needed b/c basemap was not added before

--- a/test/custom-directive.html
+++ b/test/custom-directive.html
@@ -7,7 +7,7 @@
 
         <!-- load Esri CSS  -->
         <!-- NOTE: BlendRenderer requires v3.14 -->
-        <link rel="stylesheet" type="text/css" href="http://js.arcgis.com/3.14/esri/css/esri.css">
+        <link rel="stylesheet" type="text/css" href="//js.arcgis.com/3.14/esri/css/esri.css">
         <style>
           /* NOTE: this is need b/c we are using a custom element
             and/or this is not a full screen app like the sample page */
@@ -52,9 +52,9 @@
         <p>Based on <a href="https://developers.arcgis.com/javascript/jssamples/renderer_blendrenderer_housing.html">this sample</a>.</p>
         <!-- load Esri JavaScript API -->
         <!-- NOTE: BlendRenderer requires v3.14 -->
-        <script type="text/javascript" src="http://js.arcgis.com/3.14compact"></script>
+        <script type="text/javascript" src="//js.arcgis.com/3.14compact"></script>
         <!-- load Angular -->
-        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
         <!-- load just the angular-esri-map core services -->
         <script src="lib/angular-esri-core.js"></script>
         <!-- run example app controller -->
@@ -163,7 +163,7 @@
                           ]
                         });
 
-                        var layerUrl = 'http://services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/Blocks%20near%20Wilshire%20enriched%20with%20Key%20Facts/FeatureServer/0';
+                        var layerUrl = '//services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/Blocks%20near%20Wilshire%20enriched%20with%20Key%20Facts/FeatureServer/0';
 
                         var renderer = new BlendRenderer(blendRendererParams);
 

--- a/test/deferred-map.html
+++ b/test/deferred-map.html
@@ -6,7 +6,7 @@
         <title>Deferred Map</title>
 
         <!-- load Esri CSS -->
-        <link rel="stylesheet" type="text/css" href="http://js.arcgis.com/3.11/esri/css/esri.css">
+        <link rel="stylesheet" type="text/css" href="//js.arcgis.com/3.11/esri/css/esri.css">
     </head>
     <body ng-controller="MapController">
         <h2>Deferred Map</h2>
@@ -21,7 +21,7 @@
         </div>
 
         <!-- load Angular -->
-        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
         <!-- load angular-esri-map directives -->
         <script src="lib/angular-esri-map.js"></script>
         <!-- run example app controller -->
@@ -38,7 +38,7 @@
                         // Make a call to load Esri JSAPI resources at version 3.11.
                         // A promise is provided for when the resources have finished loading.
                         esriLoader.bootstrap({
-                            url: 'http://js.arcgis.com/3.11compact'
+                            url: '//js.arcgis.com/3.11compact'
                         }).then(function() {
 
                             // Set Loaded to be true

--- a/test/dynamic-map-service-layer.html
+++ b/test/dynamic-map-service-layer.html
@@ -6,22 +6,22 @@
         <title>Dynamic Map Service Layer</title>
 
         <!-- load Esri CSS -->
-        <link rel="stylesheet" type="text/css" href="http://js.arcgis.com/3.11/esri/css/esri.css">
+        <link rel="stylesheet" type="text/css" href="//js.arcgis.com/3.11/esri/css/esri.css">
     </head>
     <body ng-controller="MapController">
         <h2>Dynamic Map Service Layer</h2>
         <!-- add map to page and bind to scope map parameters -->
         <!-- TODO: why is zoom set to -1 by default? -->
         <esri-map id="map" map-options="{ sliderOrientation : 'horizontal' }">
-            <esri-dynamic-map-service-layer url="http://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Population_World/MapServer" visible="{{dynamicLayer.visible}}" opacity="{{dynamicLayer.opacity}}" layer-options="{ imageParameters: { format: 'jpeg' } }" />
+            <esri-dynamic-map-service-layer url="//sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Population_World/MapServer" visible="{{dynamicLayer.visible}}" opacity="{{dynamicLayer.opacity}}" layer-options="{ imageParameters: { format: 'jpeg' } }" />
         </esri-map>
         <p><input type="checkbox" ng-model="dynamicLayer.visible" /> World Population - opacity: <input type="number" step="0.1" min="0" max="1" ng-model="dynamicLayer.opacity" /></p>
         <p>Based on <a href="https://developers.arcgis.com/javascript/jssamples/map_dynamic.html">this sample</a>.</p>
 
         <!-- load Esri JavaScript API -->
-        <script type="text/javascript" src="http://js.arcgis.com/3.11compact"></script>
+        <script type="text/javascript" src="//js.arcgis.com/3.11compact"></script>
         <!-- load Angular -->
-        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.min.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.min.js"></script>
         <!-- load angular-esri-map directives -->
         <script src="lib/angular-esri-map.js"></script>
         <!-- run example app controller -->

--- a/test/dynamic-map-service-layers.html
+++ b/test/dynamic-map-service-layers.html
@@ -6,7 +6,7 @@
         <title>Dynamic Map Service Layers</title>
 
         <!-- load Esri CSS -->
-        <link rel="stylesheet" type="text/css" href="http://js.arcgis.com/3.11/esri/css/esri.css">
+        <link rel="stylesheet" type="text/css" href="//js.arcgis.com/3.11/esri/css/esri.css">
         <style>
             .esriPopup .titlePane {
                 text-shadow: none;
@@ -44,7 +44,7 @@
         <esri-map id="map" map-options="::map.options" load="setInfoWindow">
             <!-- dynamic map service layer w/ inline url and options
             as well as info template defined in a directive -->
-            <esri-dynamic-map-service-layer url="http://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Petroleum/KGS_OilGasFields_Kansas/MapServer" layer-options="{ id: 'oilAndGasLayer', opacity: 0.75 }">
+            <esri-dynamic-map-service-layer url="//sampleserver1.arcgisonline.com/ArcGIS/rest/services/Petroleum/KGS_OilGasFields_Kansas/MapServer" layer-options="{ id: 'oilAndGasLayer', opacity: 0.75 }">
                 <esri-info-template layer-id="0" title="<b>Oil and Gas data</b>">
                     ${FIELD_NAME} production field<br>
                     <div class="demographicInfoContent">
@@ -58,9 +58,9 @@
         </esri-map>
         <p>Based on <a href="https://developers.arcgis.com/javascript/jssamples/map_twodynamic.html">this sample</a></p>
         <!-- load Esri JavaScript API -->
-        <script type="text/javascript" src="http://js.arcgis.com/3.11compact"></script>
+        <script type="text/javascript" src="//js.arcgis.com/3.11compact"></script>
         <!-- load Angular -->
-        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.min.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.min.js"></script>
         <!-- load angular-esri-map directives -->
         <script src="lib/angular-esri-map.js"></script>
         <!-- run example app controller -->
@@ -92,7 +92,7 @@
                     };
 
                     $scope.demographicsLayer = {
-                        url: 'http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer',
+                        url: '//sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer',
                         options: {
                             id: 'demographicsLayer',
                             opacity: 0.8,

--- a/test/feature-layers.html
+++ b/test/feature-layers.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html ng-app="esri-map-example">
     <head>
         <meta name="viewport" content="initial-scale=1.0, user-scalable=no">
@@ -6,21 +6,21 @@
         <title>Feature Layers</title>
 
         <!-- load Esri CSS -->
-        <link rel="stylesheet" type="text/css" href="http://js.arcgis.com/3.11/esri/css/esri.css">
+        <link rel="stylesheet" type="text/css" href="//js.arcgis.com/3.11/esri/css/esri.css">
     </head>
     <body ng-controller="MapController">
         <h2>Feature Layers</h2>
         <!-- add map to page and bind to scope map parameters -->
         <esri-map id="map" center="map.center" zoom="map.zoom" basemap="topo">
             <esri-feature-layer
-                url="http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0"
+                url="//services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0"
                 visible="{{map.showTrees}}"
                 definition-expression="{{map.treesDefExpression}}">
             </esri-feature-layer>
             <!-- a standalone definition-expression will take precedence over one provided within the layer-options -->
             <!-- see an example of this in the following <esri-feature-layer> -->
             <esri-feature-layer
-                url="http://services.arcgis.com/rOo16HdIMeOBI4Mb/ArcGIS/rest/services/Portland_Light_Rail_Lines/FeatureServer/0"
+                url="//services.arcgis.com/rOo16HdIMeOBI4Mb/ArcGIS/rest/services/Portland_Light_Rail_Lines/FeatureServer/0"
                 definition-expression="1=1"
                 opacity="0.85"
                 layer-options="{
@@ -50,7 +50,7 @@
                 }">
             </esri-feature-layer>
             <esri-feature-layer
-                url="http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Portland_Parks/FeatureServer/0"
+                url="//services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Portland_Parks/FeatureServer/0"
                 opacity="{{map.parksOpacity}}"
                 layer-options="{
                     outFields:['NAME', 'ACRES']
@@ -62,7 +62,7 @@
             </esri-feature-layer>
         </esri-map>
         <p><label><input type="checkbox" ng-model="map.showTrees" /> Show trees</label></p>
-        
+
         <hr>
 
         <p>Set trees definition expression, for example:
@@ -77,17 +77,17 @@
           <input type="text" ng-model="treesDefExpressionInputText" />
           <input type="submit" id="submit" value="Submit" />
         </form>
-        
+
         <hr>
 
         <p><label><input type="number" ng-model="map.parksOpacity" min="0" max="1" step="0.05"/> Set parks opacity</label></p>
         <p>Lat: {{ map.center.lat | number:3 }}, Lng: {{ map.center.lng | number:3 }}, Zoom: {{map.zoom}}</p>
-        <p>Based on <a href="http://jsfiddle.net/patrickarlt/xy3nm1sq/1/">this JS Fiddle</a>.</p>
+        <p>Based on <a href="https://jsfiddle.net/patrickarlt/xy3nm1sq/1/">this JS Fiddle</a>.</p>
 
         <!-- load Esri JavaScript API -->
-        <script type="text/javascript" src="http://js.arcgis.com/3.11compact"></script>
+        <script type="text/javascript" src="//js.arcgis.com/3.11compact"></script>
         <!-- load Angular -->
-        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
         <!-- load angular-esri-map directives -->
         <script src="lib/angular-esri-map.js"></script>
         <!-- run example app controller -->

--- a/test/layer-events.html
+++ b/test/layer-events.html
@@ -6,19 +6,19 @@
         <title>Layer Events</title>
 
         <!-- load Esri CSS -->
-        <link rel="stylesheet" type="text/css" href="http://js.arcgis.com/3.11/esri/css/esri.css">
+        <link rel="stylesheet" type="text/css" href="//js.arcgis.com/3.11/esri/css/esri.css">
     </head>
     <body ng-controller="MapController">
         <h2>Layer Events</h2>
         <!-- add map to page and bind to scope map parameters -->
         <esri-map id="map" center="map.center" zoom="map.zoom" basemap="topo">
             <esri-feature-layer
-                url="http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0"
+                url="//services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0"
                 visible="{{map.showTrees}}"
                 load="treesLayerLoaded"
                 update-end="treesLayerUpdateEnd">
             </esri-feature-layer>
-            <esri-dynamic-map-service-layer url="http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer" layer-options="{ id: 'demographicsLayer', opacity: 0.8, showAttribution: false }" visible-layers="1,2" load="demographicsLayerLoaded" update-end="demographicsLayerUpdateEnd" />
+            <esri-dynamic-map-service-layer url="//sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer" layer-options="{ id: 'demographicsLayer', opacity: 0.8, showAttribution: false }" visible-layers="1,2" load="demographicsLayerLoaded" update-end="demographicsLayerUpdateEnd" />
         </esri-map>
         <p><label><input type="checkbox" ng-model="map.showTrees" /> Show trees</label></p>
         <div class="clearfix">
@@ -53,9 +53,9 @@
         <p>Lat: {{ map.center.lat | number:3 }}, Lng: {{ map.center.lng | number:3 }}, Zoom: {{map.zoom}}</p>
 
         <!-- load Esri JavaScript API -->
-        <script type="text/javascript" src="http://js.arcgis.com/3.11compact"></script>
+        <script type="text/javascript" src="//js.arcgis.com/3.11compact"></script>
         <!-- load Angular -->
-        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
         <!-- load angular-esri-map directives -->
         <script src="lib/angular-esri-map.js"></script>
         <!-- run example app controller -->

--- a/test/legend.html
+++ b/test/legend.html
@@ -6,7 +6,7 @@
         <title>Legend</title>
 
         <!-- load Esri CSS -->
-        <link rel="stylesheet" type="text/css" href="http://js.arcgis.com/3.11/esri/css/esri.css">
+        <link rel="stylesheet" type="text/css" href="//js.arcgis.com/3.11/esri/css/esri.css">
     </head>
     <body ng-controller="MapController">
         <h2>Legend</h2>
@@ -14,8 +14,8 @@
         <div style="width: 800px">
             <div style="width: 600px; float:left;">
                 <esri-map id="map" center="map.center" zoom="map.zoom" basemap="topo" style="width: 100%">
-                  <esri-feature-layer title="Water Bodies" url="http://sampleserver3.arcgisonline.com/ArcGIS/rest/services/Hydrography/Watershed173811/MapServer/0"></esri-feature-layer>
-                  <esri-feature-layer title="Rivers" url="http://sampleserver3.arcgisonline.com/ArcGIS/rest/services/Hydrography/Watershed173811/MapServer/1"></esri-feature-layer>
+                  <esri-feature-layer title="Water Bodies" url="//sampleserver3.arcgisonline.com/ArcGIS/rest/services/Hydrography/Watershed173811/MapServer/0"></esri-feature-layer>
+                  <esri-feature-layer title="Rivers" url="//sampleserver3.arcgisonline.com/ArcGIS/rest/services/Hydrography/Watershed173811/MapServer/1"></esri-feature-layer>
                   <div esri-legend target-id="legend"></div>
                 </esri-map>
                 <p>Lat: {{ map.center.lat | number:3 }}, Lng: {{ map.center.lng | number:3 }}, Zoom: {{map.zoom}}</p>
@@ -26,9 +26,9 @@
             </div>
         </div>
         <!-- load Esri JavaScript API -->
-        <script type="text/javascript" src="http://js.arcgis.com/3.11compact"></script>
+        <script type="text/javascript" src="//js.arcgis.com/3.11compact"></script>
         <!-- load Angular -->
-        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
         <!-- load angular-esri-map directives -->
         <script src="lib/angular-esri-map.js"></script>
         <!-- run example app controller -->

--- a/test/map-events.html
+++ b/test/map-events.html
@@ -6,7 +6,7 @@
         <title>Map Events</title>
 
         <!-- load Esri CSS -->
-        <link rel="stylesheet" type="text/css" href="http://js.arcgis.com/3.11/esri/css/esri.css">
+        <link rel="stylesheet" type="text/css" href="//js.arcgis.com/3.11/esri/css/esri.css">
     </head>
     <body ng-controller="MapController">
         <h2>Map Events</h2>
@@ -16,9 +16,9 @@
         <p id="mapLoadedInfo">The map is <strong ng-show="!map.loaded">not</strong> loaded.</p>
         <p id="extentInfo">Extent: {{ map.extent.toJson() }}</p>
         <!-- load Esri JavaScript API -->
-        <script type="text/javascript" src="http://js.arcgis.com/3.11compact"></script>
+        <script type="text/javascript" src="//js.arcgis.com/3.11compact"></script>
         <!-- load Angular -->
-        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
         <!-- load angular-esri-map directives -->
         <script src="lib/angular-esri-map.js"></script>
         <!-- run example app controller -->

--- a/test/other-esri-modules.html
+++ b/test/other-esri-modules.html
@@ -6,7 +6,7 @@
         <title>Other Esri Modules</title>
 
         <!-- load Esri CSS -->
-        <link rel="stylesheet" type="text/css" href="http://js.arcgis.com/3.11/esri/css/esri.css">
+        <link rel="stylesheet" type="text/css" href="//js.arcgis.com/3.11/esri/css/esri.css">
     </head>
     <body ng-controller="MapController">
         <h2>Other Esri Modules</h2>
@@ -29,9 +29,9 @@
         </div>
         <p>Based on <a href="https://developers.arcgis.com/javascript/jssamples/graphics_add.html">this sample.</a></p>
         <!-- load Esri JavaScript API -->
-        <script type="text/javascript" src="http://js.arcgis.com/3.11compact"></script>
+        <script type="text/javascript" src="//js.arcgis.com/3.11compact"></script>
         <!-- load Angular -->
-        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
         <!-- load angular-esri-map directives -->
         <script src="lib/angular-esri-map.js"></script>
         <!-- run example app controller -->
@@ -61,7 +61,7 @@
 
                             var tb;
 
-                            // markerSymbol is used for point and multipoint, see http://raphaeljs.com/icons/#talkq for more examples
+                            // markerSymbol is used for point and multipoint, see //raphaeljs.com/icons/#talkq for more examples
                             var markerSymbol = new SimpleMarkerSymbol();
                             markerSymbol.setPath('M16,4.938c-7.732,0-14,4.701-14,10.5c0,1.981,0.741,3.833,2.016,5.414L2,25.272l5.613-1.44c2.339,1.316,5.237,2.106,8.387,2.106c7.732,0,14-4.701,14-10.5S23.732,4.938,16,4.938zM16.868,21.375h-1.969v-1.889h1.969V21.375zM16.772,18.094h-1.777l-0.176-8.083h2.113L16.772,18.094z');
                             markerSymbol.setColor(new Color('#00FFFF'));
@@ -78,7 +78,7 @@
                             // the images folder contains additional fill images, other options: sand.png, swamp.png or stiple.png
                             var fillSymbol = new PictureFillSymbol(
                                 // 'images/mangrove.png',
-                                'http://developers.arcgis.com/javascript/samples/graphics_add/images/mangrove.png',
+                                '//developers.arcgis.com/javascript/samples/graphics_add/images/mangrove.png',
                                 new SimpleLineSymbol(
                                     SimpleLineSymbol.STYLE_SOLID,
                                     new Color('#000'),

--- a/test/registry-pattern.html
+++ b/test/registry-pattern.html
@@ -6,7 +6,7 @@
         <title>Registry Pattern</title>
 
         <!-- load Esri CSS -->
-        <link rel="stylesheet" type="text/css" href="http://js.arcgis.com/3.11/esri/css/esri.css">
+        <link rel="stylesheet" type="text/css" href="//js.arcgis.com/3.11/esri/css/esri.css">
     </head>
     <body ng-controller="MapController">
         <h2>Registry Pattern</h2>
@@ -16,9 +16,9 @@
         <p ng-show="!map.point">Click the map to see point X / Y.</p>
         <p id="mapClickInfo" ng-show="map.point">Clicked point X: {{ map.point.x }}, Y: {{ map.point.y }}</p>
         <!-- load Esri JavaScript API -->
-        <script type="text/javascript" src="http://js.arcgis.com/3.11compact"></script>
+        <script type="text/javascript" src="//js.arcgis.com/3.11compact"></script>
         <!-- load Angular -->
-        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
         <!-- load angular-esri-map directives -->
         <script src="lib/angular-esri-map.js"></script>
         <!-- run example app controller -->

--- a/test/set-basemap.html
+++ b/test/set-basemap.html
@@ -6,7 +6,7 @@
         <title>Set Basemap</title>
 
         <!-- load Esri CSS -->
-        <link rel="stylesheet" type="text/css" href="http://js.arcgis.com/3.11/esri/css/esri.css">
+        <link rel="stylesheet" type="text/css" href="//js.arcgis.com/3.11/esri/css/esri.css">
     </head>
     <body ng-controller="MapController">
 
@@ -29,9 +29,9 @@
         <p>Based on <a href="https://developers.arcgis.com/javascript/jssamples/map_agol.html">this sample</a>.</p>
 
         <!-- load Esri JavaScript API -->
-        <script type="text/javascript" src="http://js.arcgis.com/3.11compact"></script>
+        <script type="text/javascript" src="//js.arcgis.com/3.11compact"></script>
         <!-- load Angular -->
-        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
         <!-- load angular-esri-map directives -->
         <script src="lib/angular-esri-map.js"></script>
         <!-- run example app controller -->

--- a/test/set-center-zoom.html
+++ b/test/set-center-zoom.html
@@ -6,7 +6,7 @@
         <title>Set Map Center and Zoom</title>
 
         <!-- load Esri CSS -->
-        <link rel="stylesheet" type="text/css" href="http://js.arcgis.com/3.11/esri/css/esri.css">
+        <link rel="stylesheet" type="text/css" href="//js.arcgis.com/3.11/esri/css/esri.css">
     </head>
     <body ng-controller="MapController">
 
@@ -24,9 +24,9 @@
         </p>
 
         <!-- load Esri JavaScript API -->
-        <script type="text/javascript" src="http://js.arcgis.com/3.11compact"></script>
+        <script type="text/javascript" src="//js.arcgis.com/3.11compact"></script>
         <!-- load Angular -->
-        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
         <!-- load angular-esri-map directives -->
         <script src="lib/angular-esri-map.js"></script>
         <!-- run example app controller -->

--- a/test/simple-map.html
+++ b/test/simple-map.html
@@ -6,7 +6,7 @@
         <title>Simple Map</title>
 
         <!-- load Esri CSS -->
-        <link rel="stylesheet" type="text/css" href="http://js.arcgis.com/3.11/esri/css/esri.css">
+        <link rel="stylesheet" type="text/css" href="//js.arcgis.com/3.11/esri/css/esri.css">
     </head>
     <body ng-controller="MapController">
         <h2>Simple Map</h2>
@@ -16,9 +16,9 @@
         <p>Based on <a href="https://developers.arcgis.com/javascript/jssamples/map_simple.html">this sample</a>.</p>
 
         <!-- load Esri JavaScript API -->
-        <script type="text/javascript" src="http://js.arcgis.com/3.11compact"></script>
+        <script type="text/javascript" src="//js.arcgis.com/3.11compact"></script>
         <!-- load Angular -->
-        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
         <!-- load angular-esri-map directives -->
         <script src="lib/angular-esri-map.js"></script>
         <!-- run example app controller -->

--- a/test/unit/core/esriLoader.spec.js
+++ b/test/unit/core/esriLoader.spec.js
@@ -36,7 +36,7 @@ describe('esriLoader', function() {
 
             describe('when not passing url in options', function() {
                 it('should default to 3.15compact', function() {
-                    var url = 'http://js.arcgis.com/3.15compact';
+                    var url = window.location.protocol + '//js.arcgis.com/3.15compact';
                     esriLoader.bootstrap();
                     expect(document.body.appendChild.calls.argsFor(0)[0].src).toEqual(url);
                 });

--- a/test/web-map.html
+++ b/test/web-map.html
@@ -6,9 +6,9 @@
         <title>Web Map</title>
 
         <!-- dijit theme only needed for chart tooltip in popup in this web map -->
-        <link rel="stylesheet" href="http://js.arcgis.com/3.11/dijit/themes/claro/claro.css">
+        <link rel="stylesheet" href="//js.arcgis.com/3.11/dijit/themes/claro/claro.css">
         <!-- load Esri CSS -->
-        <link rel="stylesheet" type="text/css" href="http://js.arcgis.com/3.11/esri/css/esri.css">
+        <link rel="stylesheet" type="text/css" href="//js.arcgis.com/3.11/esri/css/esri.css">
         <style>
         [ng-click]
         {
@@ -43,10 +43,10 @@
         </div>
         <p>Based on <a href="https://developers.arcgis.com/javascript/jssamples/ags_createwebmapid.html">this sample</a>.</p>
         <!-- load Esri JavaScript API -->
-        <script type="text/javascript" src="http://js.arcgis.com/3.11compact"></script>
+        <script type="text/javascript" src="//js.arcgis.com/3.11compact"></script>
         <!-- load Angular -->
-        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
-        <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular-sanitize.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0/angular-sanitize.js"></script>
         <!-- load angular-esri-map directives -->
         <script src="lib/angular-esri-map.js"></script>
         <!-- run example app controller -->


### PR DESCRIPTION
boostrap function in esriLoader defaults to protocol of the page
test pages and docs site (gh-pages) use protocol agnostic links to resources

resolves #179