### PR TITLE
controllers-and-scope

### DIFF
--- a/site/app/app.js
+++ b/site/app/app.js
@@ -32,7 +32,8 @@
                     $routeProvider
                         .when(example.route.path, {
                             templateUrl: example.route.templateUrl,
-                            controller: example.route.controller
+                            controller: example.route.controller,
+                            controllerAs: example.route.controllerAs
                         });
                 });
             });

--- a/site/app/appConfig.js
+++ b/site/app/appConfig.js
@@ -17,7 +17,8 @@
                 route: {
                     path: urlPrefixes.routePath + 'feature-layer',
                     templateUrl: urlPrefixes.routeTemplateUrl + 'feature-layer.html',
-                    controller: 'FeatureLayerCtrl'
+                    controller: 'FeatureLayerCtrl',
+                    controllerAs: 'FeatureLayerCtrl'
                 }
             }],
             '3D': [{
@@ -29,7 +30,8 @@
                 route: {
                     path: urlPrefixes.routePath + 'scene-view',
                     templateUrl: urlPrefixes.routeTemplateUrl + 'scene-view.html',
-                    controller: 'SceneViewCtrl'
+                    controller: 'SceneViewCtrl',
+                    controllerAs: 'SceneViewCtrl'
                 }
             }],
             Controls: [{
@@ -41,7 +43,8 @@
                 route: {
                     path: urlPrefixes.routePath + 'home-button',
                     templateUrl: urlPrefixes.routeTemplateUrl + 'home-button.html',
-                    controller: 'HomeButtonCtrl'
+                    controller: 'HomeButtonCtrl',
+                    controllerAs: 'HomeButtonCtrl'
                 }
             }]
         },

--- a/site/app/appConfig.js
+++ b/site/app/appConfig.js
@@ -18,7 +18,7 @@
                     path: urlPrefixes.routePath + 'feature-layer',
                     templateUrl: urlPrefixes.routeTemplateUrl + 'feature-layer.html',
                     controller: 'FeatureLayerCtrl',
-                    controllerAs: 'FeatureLayerCtrl'
+                    controllerAs: 'vm'
                 }
             }],
             '3D': [{
@@ -31,7 +31,7 @@
                     path: urlPrefixes.routePath + 'scene-view',
                     templateUrl: urlPrefixes.routeTemplateUrl + 'scene-view.html',
                     controller: 'SceneViewCtrl',
-                    controllerAs: 'SceneViewCtrl'
+                    controllerAs: 'vm'
                 }
             }],
             Controls: [{
@@ -44,7 +44,7 @@
                     path: urlPrefixes.routePath + 'home-button',
                     templateUrl: urlPrefixes.routeTemplateUrl + 'home-button.html',
                     controller: 'HomeButtonCtrl',
-                    controllerAs: 'HomeButtonCtrl'
+                    controllerAs: 'vm'
                 }
             }]
         },

--- a/site/app/examples/feature-layer.html
+++ b/site/app/examples/feature-layer.html
@@ -1,15 +1,13 @@
 <h2>Feature Layer</h2>
-<div ng-controller="FeatureLayerCtrl as exampleCtrl">
-    <esri-map-view map="exampleCtrl.map" 
-        view-options="{
-            extent: {
-                xmin: -9177811,
-                ymin: 4247000,
-                xmax: -9176791,
-                ymax: 4247784,
-                spatialReference: 102100
-            }
-        }">
-    </esri-map-view>
-    <p>Based on <a href="https://developers.arcgis.com/javascript/beta/sample-code/layers-featurelayer/index.html">this sample</a>.</p>
-</div>
+<esri-map-view map="FeatureLayerCtrl.map" 
+    view-options="{
+        extent: {
+            xmin: -9177811,
+            ymin: 4247000,
+            xmax: -9176791,
+            ymax: 4247784,
+            spatialReference: 102100
+        }
+    }">
+</esri-map-view>
+<p>Based on <a href="https://developers.arcgis.com/javascript/beta/sample-code/layers-featurelayer/index.html">this sample</a>.</p>

--- a/site/app/examples/feature-layer.html
+++ b/site/app/examples/feature-layer.html
@@ -1,5 +1,5 @@
 <h2>Feature Layer</h2>
-<esri-map-view map="FeatureLayerCtrl.map" 
+<esri-map-view map="vm.map" 
     view-options="{
         extent: {
             xmin: -9177811,

--- a/site/app/examples/home-button.html
+++ b/site/app/examples/home-button.html
@@ -6,7 +6,7 @@
         left: 30px;
     }
 </style>
-<esri-scene-view map="HomeButtonCtrl.map" on-create="HomeButtonCtrl.onViewCreated">
-    <esri-home-button view="HomeButtonCtrl.sceneView"></esri-home-button>
+<esri-scene-view map="vm.map" on-create="vm.onViewCreated">
+    <esri-home-button view="vm.sceneView"></esri-home-button>
 </esri-scene-view>
 <p>Based on <a href="https://developers.arcgis.com/javascript/beta/sample-code/widgets-home/index.html">this sample</a>.</p>

--- a/site/app/examples/home-button.html
+++ b/site/app/examples/home-button.html
@@ -6,9 +6,7 @@
         left: 30px;
     }
 </style>
-<div ng-controller="HomeButtonCtrl as exampleCtrl">
-    <esri-scene-view map="exampleCtrl.map" on-create="exampleCtrl.onViewCreated">
-        <esri-home-button view="exampleCtrl.sceneView"></esri-home-button>
-    </esri-scene-view>
-    <p>Based on <a href="https://developers.arcgis.com/javascript/beta/sample-code/widgets-home/index.html">this sample</a>.</p>
-</div>
+<esri-scene-view map="HomeButtonCtrl.map" on-create="HomeButtonCtrl.onViewCreated">
+    <esri-home-button view="HomeButtonCtrl.sceneView"></esri-home-button>
+</esri-scene-view>
+<p>Based on <a href="https://developers.arcgis.com/javascript/beta/sample-code/widgets-home/index.html">this sample</a>.</p>

--- a/site/app/examples/scene-view.html
+++ b/site/app/examples/scene-view.html
@@ -1,16 +1,14 @@
 <h2>Scene View</h2>
-<div ng-controller="SceneViewCtrl as exampleCtrl">
-    <esri-scene-view map="exampleCtrl.map" on-create="exampleCtrl.onViewCreated" 
-        view-options="{
-            environment: {
-                stars: 'none'
-            },
-            ui: {
-                components: ['logo']
-            }
-        }">
-    </esri-scene-view>
-    <div><label><input type="checkbox" checked ng-click="exampleCtrl.onStreetsToggle($event)" /> Transportation</label></div>
+<esri-scene-view map="SceneViewCtrl.map" on-create="SceneViewCtrl.onViewCreated" 
+    view-options="{
+        environment: {
+            stars: 'none'
+        },
+        ui: {
+            components: ['logo']
+        }
+    }">
+</esri-scene-view>
+<div><label><input type="checkbox" checked ng-click="SceneViewCtrl.onStreetsToggle($event)" /> Transportation</label></div>
 
-    <p>Based on <a href="https://developers.arcgis.com/javascript/beta/sample-code/get-started-layers/index.html">this sample</a>.</p>
-</div>
+<p>Based on <a href="https://developers.arcgis.com/javascript/beta/sample-code/get-started-layers/index.html">this sample</a>.</p>

--- a/site/app/examples/scene-view.html
+++ b/site/app/examples/scene-view.html
@@ -1,5 +1,5 @@
 <h2>Scene View</h2>
-<esri-scene-view map="SceneViewCtrl.map" on-create="SceneViewCtrl.onViewCreated" 
+<esri-scene-view map="vm.map" on-create="vm.onViewCreated" 
     view-options="{
         environment: {
             stars: 'none'
@@ -9,6 +9,6 @@
         }
     }">
 </esri-scene-view>
-<div><label><input type="checkbox" checked ng-click="SceneViewCtrl.onStreetsToggle($event)" /> Transportation</label></div>
+<div><label><input type="checkbox" checked ng-click="vm.onStreetsToggle($event)" /> Transportation</label></div>
 
 <p>Based on <a href="https://developers.arcgis.com/javascript/beta/sample-code/get-started-layers/index.html">this sample</a>.</p>


### PR DESCRIPTION
@tomwayson please review.  This is an attempt at fixing the unneeded presence of `ng-controller` in the example docs pages for v2beta1, while also avoiding any use of `$scope`.  The commit comment should provide a little more info.  This doesn't resolve any open issues; it is just some required maintenance while working on other items.  Thanks.