### PR TITLE
View options #203

### DIFF
--- a/src/map/EsriMapViewController.js
+++ b/src/map/EsriMapViewController.js
@@ -40,14 +40,6 @@
                     };
                 });
             };
-            
-            // create the view, get a ref to the promise
-            this.createViewPromise = this.createMapView(self.options).then(function(result) {
-                if (typeof self.onCreate() === 'function') {
-                    self.onCreate()(result.view);
-                }
-                return result;
-            });
 
             /**
              * @ngdoc function
@@ -55,25 +47,28 @@
              * @methodOf esri.map.controller:EsriMapViewController
              *
              * @description
-             * Set a map on the MapView
+             * Set a map on the MapView. A new MapView will be constructed
+             * if it does not already exist.
              *
              * @param {Object} map Map instance
-             *
-             * @return {Promise} Returns a $q style promise and then
-             * sets the map property and other options property on the MapView.
              */
             this.setMap = function(map) {
                 if (!map) {
                     return;
                 }
-                // preserve extent
-                if (self.options.extent && !map.initialExtent) {
-                    map.initialExtent = self.options.extent;
+
+                if (!self.view) {
+                    self.options.map = map;
+                    this.createMapView(self.options).then(function(result) {
+                        self.view = result.view;
+                        
+                        if (typeof self.onCreate() === 'function') {
+                            self.onCreate()(result.view);
+                        }
+                    });
+                } else {
+                    self.view.map = map;
                 }
-                self.options.map = map;
-                return this.createViewPromise.then(function(result) {
-                    result.view.set(self.options);
-                });
             };
         });
 })(angular);

--- a/src/map/EsriMapViewController.js
+++ b/src/map/EsriMapViewController.js
@@ -22,24 +22,27 @@
 
             /**
              * @ngdoc function
-             * @name createMapView
+             * @name getMapView
              * @methodOf esri.map.controller:EsriMapViewController
              *
              * @description
-             * Create a MapView instance
-             *
-             * @param {Object} options MapView options
+             * Load and get a reference to a MapView module
              *
              * @return {Promise} Returns a $q style promise which is
              * resolved with an object with a `view` property that refers to the MapView
              */
-            this.createMapView = function(options) {
+            this.getMapView = function() {
                 return esriLoader.require('esri/views/MapView').then(function(MapView) {
                     return {
-                        view: new MapView(options)
+                        view: MapView
                     };
                 });
             };
+
+            // load the view module, get a ref to the promise
+            this.createViewPromise = this.getMapView().then(function(result) {
+                return result;
+            });
 
             /**
              * @ngdoc function
@@ -58,15 +61,17 @@
                 }
 
                 if (!self.view) {
+                    // construct a new MapView with the supplied map and options
                     self.options.map = map;
-                    this.createMapView(self.options).then(function(result) {
-                        self.view = result.view;
-                        
+                    return this.createViewPromise.then(function(result) {
+                        self.view = new result.view(self.options);
+
                         if (typeof self.onCreate() === 'function') {
-                            self.onCreate()(result.view);
+                            self.onCreate()(self.view);
                         }
                     });
                 } else {
+                    // MapView already constructed; only set the map property
                     self.view.map = map;
                 }
             };

--- a/src/map/EsriSceneViewController.js
+++ b/src/map/EsriSceneViewController.js
@@ -41,35 +41,34 @@
                 });
             };
 
-            // create the view, get a ref to the promise
-            this.createViewPromise = this.createSceneView(self.options).then(function(result) {
-                if (typeof self.onCreate() === 'function') {
-                    self.onCreate()(result.view);
-                }
-                return result;
-            });
-
             /**
              * @ngdoc function
              * @name setMap
              * @methodOf esri.map.controller:EsriSceneViewController
              *
              * @description
-             * Set a map on the SceneView
+             * Set a map on the SceneView. A new SceneView will be constructed
+             * if it does not already exist.
              *
              * @param {Object} map Map instance
-             *
-             * @return {Promise} Returns a $q style promise and then
-             * sets the map property and other options on the SceneView.
              */
             this.setMap = function(map) {
                 if (!map) {
                     return;
                 }
-                self.options.map = map;
-                return this.createViewPromise.then(function(result) {
-                    result.view.set(self.options);
-                });
+
+                if (!self.view) {
+                    self.options.map = map;
+                    this.createSceneView(self.options).then(function(result) {
+                        self.view = result.view;
+
+                        if (typeof self.onCreate() === 'function') {
+                            self.onCreate()(result.view);
+                        }
+                    });
+                } else {
+                    self.view.map = map;
+                }
             };
         });
 })(angular);

--- a/src/map/EsriSceneViewController.js
+++ b/src/map/EsriSceneViewController.js
@@ -22,24 +22,27 @@
 
             /**
              * @ngdoc function
-             * @name createSceneView
+             * @name getSceneView
              * @methodOf esri.map.controller:EsriSceneViewController
              *
              * @description
-             * Create a SceneView instance
-             *
-             * @param {Object} options SceneView options
+             * Load and get a reference to a SceneView module
              *
              * @return {Promise} Returns a $q style promise which is
              * resolved with an object with a `view` property that refers to the SceneView
              */
-            this.createSceneView = function(options) {
+            this.getSceneView = function() {
                 return esriLoader.require('esri/views/SceneView').then(function(SceneView) {
                     return {
-                        view: new SceneView(options)
+                        view: SceneView
                     };
                 });
             };
+
+            // load the view module, get a ref to the promise
+            this.createViewPromise = this.getSceneView().then(function(result) {
+                return result;
+            });
 
             /**
              * @ngdoc function
@@ -51,6 +54,9 @@
              * if it does not already exist.
              *
              * @param {Object} map Map instance
+             *
+             * @return {Promise} Returns a $q style promise and then
+             * sets the map property and other options on the SceneView.
              */
             this.setMap = function(map) {
                 if (!map) {
@@ -58,15 +64,17 @@
                 }
 
                 if (!self.view) {
+                    // construct a new SceneView with the supplied map and options
                     self.options.map = map;
-                    this.createSceneView(self.options).then(function(result) {
-                        self.view = result.view;
+                    return this.createViewPromise.then(function(result) {
+                        self.view = new result.view(self.options);
 
                         if (typeof self.onCreate() === 'function') {
-                            self.onCreate()(result.view);
+                            self.onCreate()(self.view);
                         }
                     });
                 } else {
+                    // SceneView already constructed; only set the map property
                     self.view.map = map;
                 }
             };

--- a/test/feature-layer.html
+++ b/test/feature-layer.html
@@ -26,10 +26,12 @@
                         xmax: -9176791,
                         ymax: 4247784,
                         spatialReference: 102100
-                    }
+                    },
+                    rotation: 90
                 }">
                 <esri-home-button view="exampleCtrl.mapView"></esri-home-button>
             </esri-map-view>
+            <button ng-click="exampleCtrl.changeMap()">Change map for this esri-map-view</button>
             <p>Based on <a href="https://developers.arcgis.com/javascript/beta/sample-code/layers-featurelayer/index.html">this sample</a>.</p>
         </div>
         <!-- load Esri JavaScript API -->
@@ -67,6 +69,19 @@
 
                         self.onViewCreated = function(view) {
                             self.mapView = view;
+                        };
+
+                        self.changeMap = function() {
+                            esriLoader.require([
+                                'esri/Map'
+                            ], function(Map) {
+
+                                // create the map
+                                // and add a feature layer
+                                self.map = new Map({
+                                    basemap: 'gray'
+                                });
+                            });
                         };
                     });
                 });

--- a/test/feature-layer.html
+++ b/test/feature-layer.html
@@ -52,19 +52,18 @@
                     var self = this;
                     // load esri modules
                     esriLoader.require([
-                      'esri/Map',
-                      'esri/layers/FeatureLayer'
+                        'esri/Map',
+                        'esri/layers/FeatureLayer'
                     ], function(Map, FeatureLayer) {
-
                         // create the map
                         // and add a feature layer
                         self.map = new Map({
-                          basemap: 'hybrid',
-                          layers: [
-                              new FeatureLayer({
-                                  url: '//services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/Landscape_Trees/FeatureServer/0'
-                              })
-                          ]
+                            basemap: 'hybrid',
+                            layers: [
+                                new FeatureLayer({
+                                    url: '//services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/Landscape_Trees/FeatureServer/0'
+                                })
+                            ]
                         });
 
                         self.onViewCreated = function(view) {
@@ -72,15 +71,10 @@
                         };
 
                         self.changeMap = function() {
-                            esriLoader.require([
-                                'esri/Map'
-                            ], function(Map) {
-
-                                // create the map
-                                // and add a feature layer
-                                self.map = new Map({
-                                    basemap: 'gray'
-                                });
+                            // create the map
+                            // and add a feature layer
+                            self.map = new Map({
+                                basemap: 'gray'
                             });
                         };
                     });

--- a/test/scene-view.html
+++ b/test/scene-view.html
@@ -43,31 +43,30 @@
                     function(
                         Map, SceneView, ArcGISTiledLayer
                     ) {
-
                         /*****************************************************************
                          * Create two ArcGISTiledLayer instances. One pointing to a
                          * cached map service depicting U.S. male population and the other
                          * pointing to a layer of roads and highways.
                          *****************************************************************/
                         var transportationLyr = new ArcGISTiledLayer({
-                          url: '//server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Transportation/MapServer',
-                          //This property can be used to uniquely identify the layer
-                          id: 'streets'
+                            url: '//server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Transportation/MapServer',
+                            //This property can be used to uniquely identify the layer
+                            id: 'streets'
                         });
 
                         var popLyr = new ArcGISTiledLayer({
-                          url: '//services.arcgisonline.com/arcgis/rest/services/Demographics/USA_Population_by_Sex/MapServer',
-                          id: 'male-population',
-                          //controls the opacity of the layer
-                          opacity: 0.7
+                            url: '//services.arcgisonline.com/arcgis/rest/services/Demographics/USA_Population_by_Sex/MapServer',
+                            id: 'male-population',
+                            //controls the opacity of the layer
+                            opacity: 0.7
                         });
 
                         /*****************************************************************
                          * Layers may be added to the map in the map's constructor
                          *****************************************************************/
                         self.map = new Map({
-                          basemap: 'dark-gray',
-                          layers: [popLyr]
+                            basemap: 'dark-gray',
+                            layers: [popLyr]
                         });
 
                         /*****************************************************************
@@ -93,24 +92,19 @@
                          * the layer is still part of the map, which means you can access
                          * its properties and perform analysis even though it isn't visible.
                          *******************************************************************/
-                         self.onStreetsToggle = function(e) {
+                        self.onStreetsToggle = function(e) {
                             transportationLyr.visible = !!e.currentTarget.checked;
-                         }
-                    });
+                        }
 
-                    self.changeMap = function() {
-                        esriLoader.require([
-                            'esri/Map'
-                        ], function(Map) {
-
+                        self.changeMap = function() {
                             // create the map
                             // and add a feature layer
                             self.map = new Map({
                                 basemap: 'gray'
                             });
-                        });
-                    };
+                        };
                     });
+                });
         </script>
     </body>
 </html>

--- a/test/scene-view.html
+++ b/test/scene-view.html
@@ -14,6 +14,8 @@
             <esri-scene-view map="exampleCtrl.map" on-create="exampleCtrl.onViewCreated"></esri-scene-view>
             <div><label><input type="checkbox" checked ng-click="exampleCtrl.onStreetsToggle($event)" /> Transportation</label></div>
 
+            <button ng-click="exampleCtrl.changeMap()">Change map for this esri-scene-view</button>
+
             <p>Based on <a href="https://developers.arcgis.com/javascript/beta/sample-code/get-started-layers/index.html">this sample</a>.</p>
         </div>
         <!-- load Esri JavaScript API -->
@@ -95,7 +97,20 @@
                             transportationLyr.visible = !!e.currentTarget.checked;
                          }
                     });
-                });
+
+                    self.changeMap = function() {
+                        esriLoader.require([
+                            'esri/Map'
+                        ], function(Map) {
+
+                            // create the map
+                            // and add a feature layer
+                            self.map = new Map({
+                                basemap: 'gray'
+                            });
+                        });
+                    };
+                    });
         </script>
     </body>
 </html>


### PR DESCRIPTION
@tomwayson please review; resolves #203.

I found that it was crucial to keep your original work with getting an immediate reference to a promise for esriLoading a `MapView` or `SceneView` module.  Without this--and instead AMD loading within the `setMap` method--sometimes I'd find myself outside of the Angular digest cycle and nothing would load in a `<esri-*-view>` directive.

Ultimately, this code now _constructs_ a new `MapView` or `SceneView` with all options + a valid map instance inside of the `setMap` method.

Otherwise, just for illustration, I added a button to change the `map` property for the scene-view and feature-layer test pages.  You'll see that the feature-layer test page will not behave :100:% right when attempting to change the map property, and I think this has to do with the original map having layers.  Remove the layers yourself in the sample code, run it again, and then it should be fine when switching out the map.