### PR TITLE
Require callback digest

### DIFF
--- a/site/app/examples/chaining-promises.js
+++ b/site/app/examples/chaining-promises.js
@@ -40,13 +40,13 @@ angular.module('esri-map-docs')
             });
 
             // create the map for the esri-scene-view
-            var map = new Map({
+            self.map = new Map({
                 basemap: 'hybrid'
             });
 
             // create layer to store graphics and add to map
             var layer = new GraphicsLayer();
-            map.add(layer);
+            self.map.add(layer);
 
             // location of meteor crater centroid in Arizona desert
             var meteorPoint = new Point({
@@ -66,12 +66,6 @@ angular.module('esri-map-docs')
                     .then(calculateArea)    // when promise resolves, send buffer to calculateArea()
                     .then(printArea);       // when promise resolves, send buffer to printArea()
             };
-
-            // after loading AMD modules, we are likely outside of the digest cycle
-            // apply scope to establish the bound "map" property
-            $scope.$evalAsync(function() {
-                self.map = map;
-            });
 
             // adds the point and buffer graphics to the layer
             function addGraphics(buffer) {

--- a/site/app/examples/search.js
+++ b/site/app/examples/search.js
@@ -24,7 +24,5 @@ angular.module('esri-map-docs')
                     searchWidget.destroy();
                 });
             };
-
-            $scope.$evalAsync();
         });
     });

--- a/site/app/examples/webscene-slides.js
+++ b/site/app/examples/webscene-slides.js
@@ -17,9 +17,7 @@ angular.module('esri-map-docs')
             });
 
             // establish the WebScene as the bound "map" property for the <esri-scene-view>
-            $scope.$evalAsync(function() {
-                self.map = webScene;
-            });
+            self.map = webScene;
         });
 
         self.onViewCreated = function(view) {

--- a/src/core/esriLoader.js
+++ b/src/core/esriLoader.js
@@ -78,38 +78,44 @@
             var deferred = $q.defer();
 
             // Throw Error if Esri is not loaded yet
-            if ( !isLoaded() ) {
+            if (!isLoaded()) {
                 deferred.reject('Trying to call esriLoader.require(), but Esri ArcGIS API has not been loaded yet. Run esriLoader.bootstrap() if you are lazy loading Esri ArcGIS API.');
                 return deferred.promise;
             }
+            
             if (typeof moduleName === 'string') {
                 require([moduleName], function (module) {
+                    // grab the single module passed back from require callback and send to promise
+                    deferred.resolve(module);
+                });
 
-                    // Check if callback exists, and execute if it does
+                // return a chained promise that calls the callback function
+                //  to ensure it occurs within the digest cycle
+                return deferred.promise.then(function(module) {
                     if (callback && typeof callback === 'function') {
                         callback(module);
                     }
-                    deferred.resolve(module);
+                    return module;
                 });
-            }
-            else if (moduleName instanceof Array) {
+            } else if (moduleName instanceof Array) {
                 require(moduleName, function () {
+                    var modules = Array.prototype.slice.call(arguments);
+                    // grab all of the modules passed back from require callback and send as array to promise
+                    deferred.resolve(modules);
+                });
 
-                    var args = Array.prototype.slice.call(arguments);
-
-                    // callback check, sends modules loaded as arguments
+                // return a chained promise that calls the callback function
+                //  to ensure it occurs within the digest cycle
+                return deferred.promise.then(function(modules) {
                     if (callback && typeof callback === 'function') {
-                        callback.apply(this, args);
+                        callback.apply(this, modules);
                     }
-
-                    // Grab all of the modules pass back from require callback and send as array to promise.
-                    deferred.resolve(args);
+                    return modules;
                 });
             } else {
                 deferred.reject('An Array<String> or String is required to load modules.');
+                return deferred.promise;
             }
-
-            return deferred.promise;
         }
 
         // Return list of aformentioned functions

--- a/test/chaining-promises.html
+++ b/test/chaining-promises.html
@@ -90,13 +90,13 @@
                         });
 
                         // create the map for the esri-scene-view
-                        var map = new Map({
+                        self.map = new Map({
                             basemap: 'hybrid'
                         });
 
                         // create layer to store graphics and add to map
                         var layer = new GraphicsLayer();
-                        map.add(layer);
+                        self.map.add(layer);
 
                         // location of meteor crater centroid in Arizona desert
                         var meteorPoint = new Point({
@@ -116,12 +116,6 @@
                                 .then(calculateArea)    // when promise resolves, send buffer to calculateArea()
                                 .then(printArea);       // when promise resolves, send buffer to printArea()
                         };
-
-                        // after loading AMD modules, we are likely outside of the digest cycle
-                        // apply scope to establish the bound "map" property
-                        $scope.$evalAsync(function() {
-                            self.map = map;
-                        });
 
                         // adds the point and buffer graphics to the layer
                         function addGraphics(buffer) {

--- a/test/search.html
+++ b/test/search.html
@@ -69,8 +69,6 @@
                                 searchWidget.destroy();
                             });
                         };
-
-                        $scope.$evalAsync();
                     });
                 });
         </script>

--- a/test/unit/core/esriLoader.spec.js
+++ b/test/unit/core/esriLoader.spec.js
@@ -119,10 +119,10 @@ describe('esriLoader', function() {
                         esriLoader.require('notARealModuleName', callback);
                         expect(window.require.calls.argsFor(0)[0]).toEqual(['notARealModuleName']);
                     });
-                    it('should call the callback with 1 argument', function() {
+                    /*it('should call the callback with 1 argument', function() {
                         esriLoader.require('notARealModuleName', callback);
                         expect(callback.calls.argsFor(0).length).toEqual(1);
-                    });
+                    });*/
                 });
                 describe('and no callback function', function() {
                     it('should call require with an array of module names', function() {
@@ -150,10 +150,10 @@ describe('esriLoader', function() {
                         esriLoader.require(['notARealModuleName', 'anotherOne'], callback);
                         expect(window.require.calls.argsFor(0)[0]).toEqual(['notARealModuleName', 'anotherOne']);
                     });
-                    it('should call the callback function with more than 1 argument', function() {
+                    /*it('should call the callback function with more than 1 argument', function() {
                         esriLoader.require(['notARealModuleName', 'anotherOne'], callback);
                         expect(callback.calls.argsFor(0).length).toEqual(2);
-                    });
+                    });*/
                 });
                 describe('and no callback function', function() {
                     it('should call require with an array of module names', function() {

--- a/test/unit/core/esriLoader.spec.js
+++ b/test/unit/core/esriLoader.spec.js
@@ -119,10 +119,11 @@ describe('esriLoader', function() {
                         esriLoader.require('notARealModuleName', callback);
                         expect(window.require.calls.argsFor(0)[0]).toEqual(['notARealModuleName']);
                     });
-                    /*it('should call the callback with 1 argument', function() {
+                    it('should call the callback with 1 argument', function() {
                         esriLoader.require('notARealModuleName', callback);
+                        $rootScope.$digest();
                         expect(callback.calls.argsFor(0).length).toEqual(1);
-                    });*/
+                    });
                 });
                 describe('and no callback function', function() {
                     it('should call require with an array of module names', function() {
@@ -150,10 +151,11 @@ describe('esriLoader', function() {
                         esriLoader.require(['notARealModuleName', 'anotherOne'], callback);
                         expect(window.require.calls.argsFor(0)[0]).toEqual(['notARealModuleName', 'anotherOne']);
                     });
-                    /*it('should call the callback function with more than 1 argument', function() {
+                    it('should call the callback function with more than 1 argument', function() {
                         esriLoader.require(['notARealModuleName', 'anotherOne'], callback);
+                        $rootScope.$digest();
                         expect(callback.calls.argsFor(0).length).toEqual(2);
-                    });*/
+                    });
                 });
                 describe('and no callback function', function() {
                     it('should call require with an array of module names', function() {

--- a/test/webscene-slides.html
+++ b/test/webscene-slides.html
@@ -81,9 +81,7 @@
                         });
 
                         // establish the WebScene as the bound "map" property for the <esri-scene-view>
-                        $scope.$evalAsync(function() {
-                            self.map = webScene;
-                        });
+                        self.map = webScene;
                     });
 
                     self.onViewCreated = function(view) {
@@ -99,6 +97,9 @@
                             });
 
                             // manually apply scope since we are outside of the Angular digest cycle
+                            /*
+                                NOTE: check if this can go away after the on-load hook is added to src instead
+                            */
                             $scope.$apply('exampleCtrl.slides');
                         });
                     };


### PR DESCRIPTION
@tomwayson please review.  This resolves #219, using option 2 as we discussed.

The first commit has the standalone changes to `esriLoader.require` and it's unit tests so we can re-use that back to v1.

A couple unit tests have been commented out and I'd appreciate your input on those to help adjust the mocks to get them to work again.

As far as the `esriLoader.require` code changes go, it seems to work well!  It might benefit from cutting out some redundant code, but I couldn't come up with a straightforward way to trim it down.