### PR TITLE
autoscroll-ngview

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -69,7 +69,7 @@
             </div>
 
             <!-- page content for ngRoute; apply a column size if the examples left nav is visible -->
-            <div ng-view="" ng-class="{'col-sm-9': (examplesLeftNavShow || patternsLeftNavShow)}"></div>
+            <div ng-view="" autoscroll ng-class="{'col-sm-9': (examplesLeftNavShow || patternsLeftNavShow)}"></div>
 
             <!-- source code snippets -->
             <div>


### PR DESCRIPTION
resolves #226; added autoscroll property to ng-view to scroll to the top on route change

@tomwayson please check it out. No rush. I think it is a decent fix if on a desktop browser, but when it is responsive (e.g. mobile device) the scroll to the top behavior might be jarring.

As an alternative, I played around with the following during the route change listener (see leftNavController.js) to actually scroll to, say an `<h2 id="xyzID">` element in an example page, but I still saw the JSAPI flickering/flashing somtimes.

```javascript
$location.hash('xyzID');
$anchorScroll();
```