### PR TITLE
View directives on error

### DIFF
--- a/site/app/examples/chaining-promises.html
+++ b/site/app/examples/chaining-promises.html
@@ -12,15 +12,20 @@
     }
 </style>
 <h2>Chaining Promises</h2>
-<div style="position:relative;">
-    <esri-scene-view map="vm.map" on-create="vm.onViewCreated">
-    <div id="results">
-        <!-- <button ng-click="vm.onStartButtonClick()" ng-disabled="vm.area">Start Promise Chain</button> -->
-        <button type="button" class="btn btn-sm btn-default" ng-click="vm.onStartButtonClick()" ng-disabled="vm.area">Start Promise Chain</button>
-        <span id="areaSpan" ng-hide="!vm.area">
-            <br><br>Area = {{vm.area | number: 0}} acres
-        </span>
-    </div>
+
+<div class="web-gl-warning" ng-show="vm.showViewError">WebGL is not supported on your platform/browser.</div>
+
+<div ng-hide="vm.showViewError" style="position:relative;">
+    <esri-scene-view map="vm.map" on-create="vm.onViewCreated" on-error="vm.onViewError">
+        <div id="results">
+            <button type="button" class="btn btn-sm btn-default" ng-click="vm.onStartButtonClick()" ng-disabled="vm.area">
+                Start Promise Chain
+            </button>
+            <span id="areaSpan" ng-hide="!vm.area">
+                <br><br>Area = {{vm.area | number: 0}} acres
+            </span>
+        </div>
     </esri-scene-view>
 </div>
+
 <p>Based on <a href="https://developers.arcgis.com/javascript/beta/sample-code/chaining-promises/index.html">this sample</a>.</p>

--- a/site/app/examples/chaining-promises.js
+++ b/site/app/examples/chaining-promises.js
@@ -58,6 +58,10 @@ angular.module('esri-map-docs')
                 self.view = view;
             };
 
+            self.onViewError = function() {
+                self.showViewError = true;
+            };
+
             self.onStartButtonClick = function() {
                 // buffer crater point and chain promise to additional functions
                 geometryEngineAsync.geodesicBuffer(meteorPoint, 700, 'yards')

--- a/site/app/examples/extrude-polygon.html
+++ b/site/app/examples/extrude-polygon.html
@@ -1,4 +1,7 @@
 <h2>Extrude Polygon by Visual Variables</h2>
+
+<div class="web-gl-warning" ng-show="vm.showViewError">WebGL is not supported on your platform/browser.</div>
+
 <esri-scene-view map="vm.map" 
     view-options="{
         camera: {
@@ -6,6 +9,9 @@
             tilt: 30,
             heading: 23
         }
-    }">
+    }"
+    on-error="vm.onViewError"
+    ng-hide="vm.showViewError">
 </esri-scene-view>
+
 <p>Based on <a href="https://developers.arcgis.com/javascript/beta/sample-code/polygon-extrusion-3d/index.html">this sample</a>.</p>

--- a/site/app/examples/extrude-polygon.js
+++ b/site/app/examples/extrude-polygon.js
@@ -16,6 +16,10 @@ angular.module('esri-map-docs')
                 basemap: 'streets'
             });
 
+            self.onViewError = function() {
+                self.showViewError = true;
+            };
+
             //Create featureLayer and add to the map
             var featureLayer = new FeatureLayer({
                 url: '//sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3'

--- a/site/app/examples/geodesic-buffers.html
+++ b/site/app/examples/geodesic-buffers.html
@@ -23,6 +23,9 @@
     }
 </style>
 <h2>Geodesic Buffers</h2>
+
+<div class="web-gl-warning" ng-show="vm.showViewError">WebGL is not supported on your platform/browser.</div>
+
 <esri-map-view class="viewDivBase" id="viewDiv2d" 
     map="vm.map"
     view-options="{
@@ -37,7 +40,9 @@
     view-options="{
         zoom: 4,
         center: [0, 45]
-    }">
+    }"
+    on-error="vm.onViewError"
+    ng-hide="vm.showViewError">
     <div class="title">SceneView</div>
 </esri-scene-view>
 

--- a/site/app/examples/geodesic-buffers.js
+++ b/site/app/examples/geodesic-buffers.js
@@ -24,6 +24,10 @@ angular.module('esri-map-docs')
                 basemap: 'satellite'
             });
 
+            self.onViewError = function() {
+                self.showViewError = true;
+            };
+
             /********************************************************************
              * Add two graphics layers to map: one for points, another for buffers
              ********************************************************************/

--- a/site/app/examples/home-button.html
+++ b/site/app/examples/home-button.html
@@ -6,7 +6,11 @@
     }
 </style>
 <h2>Home Button</h2>
-<esri-scene-view map="vm.map" on-create="vm.onViewCreated">
+
+<div class="web-gl-warning" ng-show="vm.showViewError">WebGL is not supported on your platform/browser.</div>
+
+<esri-scene-view map="vm.map" on-create="vm.onViewCreated" on-error="vm.onViewError" ng-hide="vm.showViewError">
     <esri-home-button view="vm.sceneView"></esri-home-button>
 </esri-scene-view>
+
 <p>Based on <a href="https://developers.arcgis.com/javascript/beta/sample-code/widgets-home/index.html">this sample</a>.</p>

--- a/site/app/examples/home-button.js
+++ b/site/app/examples/home-button.js
@@ -10,5 +10,9 @@ angular.module('esri-map-docs')
             self.onViewCreated = function(view) {
                 self.sceneView = view;
             };
+
+            self.onViewError = function() {
+                self.showViewError = true;
+            };
         });
     });

--- a/site/app/examples/scene-toggle-elevation.html
+++ b/site/app/examples/scene-toggle-elevation.html
@@ -14,17 +14,23 @@
     }
 </style>
 <h2>Toggle the Basemap's Elevation Layer</h2>
-<div style="position:relative;">
-    <esri-scene-view map="vm.map" on-create="vm.onViewCreated" 
+
+<div class="web-gl-warning" ng-show="vm.showViewError">WebGL is not supported on your platform/browser.</div>
+
+<div ng-hide="vm.showViewError" style="position:relative;">
+    <esri-scene-view map="vm.map" 
         view-options="{
             camera: {
                 position: [7.654, 45.919, 5184],
                 tilt: 80
             }
-        }">
+        }"
+        on-create="vm.onViewCreated"
+        on-error="vm.onViewError">
     </esri-scene-view>
     <div id="elevationDiv">
         <label>Elevation: <input type="checkbox" checked ng-click="vm.updateElevation($event)" /></label>
     </div>
 </div>
+
 <p>Based on <a href="https://developers.arcgis.com/javascript/beta/sample-code/scene-toggle-elevation/index.html">this sample</a>.</p>

--- a/site/app/examples/scene-toggle-elevation.js
+++ b/site/app/examples/scene-toggle-elevation.js
@@ -16,6 +16,10 @@ angular.module('esri-map-docs')
                 });
             };
 
+            self.onViewError = function() {
+                self.showViewError = true;
+            };
+
             self.updateElevation = function(e) {
                 if (!e.currentTarget.checked) {
                     // clear all elevation layers

--- a/site/app/examples/scene-view.html
+++ b/site/app/examples/scene-view.html
@@ -1,5 +1,8 @@
 <h2>Scene View</h2>
-<esri-scene-view map="vm.map" on-create="vm.onViewCreated" 
+
+<div class="web-gl-warning" ng-show="vm.showViewError">WebGL is not supported on your platform/browser.</div>
+
+<esri-scene-view map="vm.map" 
     view-options="{
         environment: {
             stars: 'none'
@@ -7,8 +10,14 @@
         ui: {
             components: ['logo']
         }
-    }">
+    }"
+    on-create="vm.onViewCreated" 
+    on-error="vm.onViewError"
+    ng-hide="vm.showViewError">
 </esri-scene-view>
-<div><label><input type="checkbox" checked ng-click="vm.onStreetsToggle($event)" /> Transportation</label></div>
+
+<div ng-hide="vm.showViewError">
+	<label><input type="checkbox" checked ng-click="vm.onStreetsToggle($event)" /> Transportation</label>
+</div>
 
 <p>Based on <a href="https://developers.arcgis.com/javascript/beta/sample-code/get-started-layers/index.html">this sample</a>.</p>

--- a/site/app/examples/scene-view.js
+++ b/site/app/examples/scene-view.js
@@ -32,6 +32,10 @@ angular.module('esri-map-docs')
                 });
             };
 
+            self.onViewError = function() {
+                self.showViewError = true;
+            };
+
             // toggle transportation layer based on user click
             self.onStreetsToggle = function(e) {
                 transportationLyr.visible = !!e.currentTarget.checked;

--- a/site/app/examples/webscene-slides.html
+++ b/site/app/examples/webscene-slides.html
@@ -25,8 +25,11 @@
     }
 </style>
 <h2>Work with Slides in a WebScene</h2>
-<div style="position:relative;">
-    <esri-scene-view map="vm.map" on-load="vm.onViewLoaded"></esri-scene-view>
+
+<div class="web-gl-warning" ng-show="vm.showViewError">WebGL is not supported on your platform/browser.</div>
+
+<div ng-hide="vm.showViewError" style="position:relative;">
+    <esri-scene-view map="vm.map" on-load="vm.onViewLoaded" on-error="vm.onViewError"></esri-scene-view>
     <div class="slidesDiv" ng-show="vm.slides.length > 0">
         <span class="slide" ng-repeat="slide in vm.slides" ng-click="vm.onSlideClick(slide)">
             {{slide.title.text}}
@@ -36,4 +39,5 @@
         </span>
     </div>
 </div>
+
 <p>Based on <a href="https://developers.arcgis.com/javascript/beta/sample-code/layers-featurelayer/index.html">this sample</a>.</p>

--- a/site/app/examples/webscene-slides.js
+++ b/site/app/examples/webscene-slides.js
@@ -34,6 +34,10 @@ angular.module('esri-map-docs')
                 });
             };
 
+            self.onViewError = function() {
+                self.showViewError = true;
+            };
+
             self.onSlideClick = function(slide) {
                 self.slides.forEach(function(slide) {
                     slide.isActiveSlide = false;

--- a/site/app/patterns/references-to-views.html
+++ b/site/app/patterns/references-to-views.html
@@ -7,7 +7,21 @@
             manipulate those objects in ways beyond what is allowed by the
             declarative directive API.</p>
         <h3>Events</h3>
-        <p>The map and scene view directives each include both <code>on-create</code> and <code>on-load</code> events that pass a reference to the underlying map or scene view object to a callback function. The <code>on-create</code> event is fired immediately after the view has been created (i.e. <code>new MapView()</code>) and the <code>on-load</code> event fires after the view's <a href="https://developers.arcgis.com/javascript/beta/api-reference/esri-Map.html#then">promise has been resolved</a>. See these examples:</p>
+        <p>The map and scene view directives each include both <code>on-create</code>
+            and <code>on-load</code> events that pass a reference to the underlying map or
+            scene view object to a callback function. The <code>on-create</code> event is
+            fired immediately after the view has been created (i.e. <code>new MapView()</code>)
+            and the <code>on-load</code> event fires after the view's
+            <a href="https://developers.arcgis.com/javascript/beta/api-reference/esri-views-MapView.html#then">promise has been resolved</a>.
+        </p> 
+        <p>The map and scene view directives also include an <code>on-error</code> event
+            that passes the error information object if a view's promise has been rejected.
+            This can be useful, for example, if you wish to use a scene view directive but
+            need to <a href="https://developers.arcgis.com/javascript/beta/sample-code/scene-webgl-support/index.html">gracefully handle</a>
+            browsers that do not support WebGL. Most examples using the scene view directive
+            also demonstrate how to use this binding.
+        </p>
+        <p>See these examples:</p>
         <h4>On-create</h4>
         <ul>
             <li><a href="#/examples/scene-view">Scene View</a></li>

--- a/site/styles/main.css
+++ b/site/styles/main.css
@@ -26,6 +26,11 @@
   margin: 0 0 10px 0;
 }
 
+.web-gl-warning {
+  color: #b52e31;
+  font-weight: bold;
+}
+
 /* Esri JSAPI */
 .esri-view {
   height: 400px;

--- a/src/map/EsriMapViewController.js
+++ b/src/map/EsriMapViewController.js
@@ -47,8 +47,10 @@
              * @methodOf esri.map.controller:EsriMapViewController
              *
              * @description
-             * Set a Map on the MapView. A new MapView will be constructed
-             * if it does not already exist, and also execute optional `on-load` and `on-create` events.
+             * Set a Map on the MapView.
+             * A new MapView will be constructed if it does not already exist,
+             * and also execute the optional `on-load` and `on-create` events.
+             * If a new MapView is rejected, the optional `on-error` event will be executed.
              *
              * @param {Object} map Map instance
              */
@@ -72,6 +74,10 @@
                                 $scope.$apply(function() {
                                     self.onLoad()(self.view);
                                 });
+                            }
+                        }, function(err) {
+                            if (typeof self.onError() === 'function') {
+                                self.onError()(err);
                             }
                         });
                     });

--- a/src/map/EsriSceneViewController.js
+++ b/src/map/EsriSceneViewController.js
@@ -47,8 +47,10 @@
              * @methodOf esri.map.controller:EsriSceneViewController
              *
              * @description
-             * Set a Map or WebScene on the SceneView. A new SceneView will be constructed
-             * if it does not already exist, and also execute optional `on-load` and `on-create` events.
+             * Set a Map or WebScene on the SceneView.
+             * A new SceneView will be constructed if it does not already exist,
+             * and also execute the optional `on-load` and `on-create` events.
+             * If a new SceneView is rejected, the optional `on-error` event will be executed.
              *
              * @param {Object} map Map instance or WebScene instance
              *
@@ -75,6 +77,10 @@
                                 $scope.$apply(function() {
                                     self.onLoad()(self.view);
                                 });
+                            }
+                        }, function(err) {
+                            if (typeof self.onError() === 'function') {
+                                self.onError()(err);
                             }
                         });
                     });

--- a/src/map/esriMapView.js
+++ b/src/map/esriMapView.js
@@ -18,6 +18,7 @@
      * @param {Object} map Instance of a Map.
      * @param {Function=} on-create Callback for successful creation of the map view.
      * @param {Function=} on-load Callback for successful loading of the map view.
+     * @param {Function=} on-error Callback for rejected/failed loading of the map view.
      * @param {Object | String=} view-options An object or inline object hash string defining additional map view constructor options.
      */
     angular.module('esri.map')
@@ -35,6 +36,7 @@
                     // function binding for event handlers
                     onCreate: '&',
                     onLoad: '&',
+                    onError: '&',
                     // function binding for reading object hash from attribute string
                     // or from scope object property
                     viewOptions: '&'

--- a/src/map/esriSceneView.js
+++ b/src/map/esriSceneView.js
@@ -18,6 +18,7 @@
      * @param {Object} map Instance of a Map or WebScene.
      * @param {Function=} on-create Callback for successful creation of the scene view.
      * @param {Function=} on-load Callback for successful loading of the scene view.
+     * @param {Function=} on-error Callback for rejected/failed loading of the scene view, for example when WebGL is not supported.
      * @param {Object | String=} view-options An object or inline object hash string defining additional scene view constructor options.
      */
     angular.module('esri.map')
@@ -35,6 +36,7 @@
                     // function binding for event handlers
                     onCreate: '&',
                     onLoad: '&',
+                    onError: '&',
                     // function binding for reading object hash from attribute string
                     // or from scope object property
                     viewOptions: '&'


### PR DESCRIPTION
@tomwayson please review.

I actually had to do the following in Chrome (48.0.2564.109):
`chrome://flags/`: Disable 3D software rasterizer (yes, do this)
`chrome://settings/`: Use hardware acceleration when available (you might also have to un-check this)

Resolves #239 
Resolves #240

I tried to split different concerns into different commits:
- I added new info about the `on-error` to the patterns page about the other events, but perhaps that wasn't the perfect place to dump in that new info.
- Also, I don't know of a good way to functionally e2e test the addition of the `on-error` event to the view directives test pages, so only the site examples currently benefit from this.