### PR TITLE
added angular dependency for npm and bower

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Maintenance
 Unminified dist files adhere to strict dependecy injection (DI). Note that minified dist files already had strict DI. [#269](https://github.com/Esri/angular-esri-map/issues/269)
 
+Angular dependencies (^1.3.0) declared for package.json (`npm install`) and bower.json (`bower install`). [#275](https://github.com/Esri/angular-esri-map/issues/275)
+
 ### Documentation
 Added readme links to recent presentation slides.
 

--- a/bower.json
+++ b/bower.json
@@ -24,5 +24,8 @@
     "bower_components",
     "test",
     "gulpfile.js"
-  ]
+  ],
+  "dependencies": {
+    "angular": "^1.3.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "2.0.0-beta.2",
   "description": "A collection of directives to help you use Esri maps and services in your Angular applications",
   "main": "dist/angular-esri-map.js",
-  "dependencies": {},
+  "dependencies": {
+    "angular": "^1.3.0"
+  },
   "devDependencies": {
     "angular": "^1.4.7",
     "angular-mocks": "^1.4.7",


### PR DESCRIPTION
Proposed changes:
  - Should be able to automatically get the Angular dependency when creating a new app with npm or bower.
  - test that it works with bower: `bower install angular-esri-map#npm-bower-angular-deps`
  - test that it works with npm: `npm install https://github.com/Esri/angular-esri-map.git#npm-bower-angular-deps`

@tomwayson please review

Resolves #275 
