### PR TITLE
V2 docs links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Upcoming changes][unreleased]
 
+### Documentation
+
+Documentation site examples, patterns, and API pages were updated to have more links back to Esri docs and more consistency among module naming conventions. [#290](https://github.com/Esri/angular-esri-map/issues/290)
+
 ## [v2.0.0]
 
 ### Maintenance
@@ -14,7 +18,6 @@ Unminified dist files adhere to strict dependecy injection (DI). Note that minif
 Angular dependencies (^1.3.0) declared for package.json (`npm install`) and bower.json (`bower install`). [#275](https://github.com/Esri/angular-esri-map/issues/275)
 
 Source code, test pages, unit tests, and e2e tests were updated for the Esri JSAPI 4.0 release. The `<esri-home-button>` directive was given a new bound property (`view-ui-position`) to be able to specify its position in a MapView or SceneView. [#282](https://github.com/Esri/angular-esri-map/pull/282)
-
 
 ### Documentation
 

--- a/site/app/app.js
+++ b/site/app/app.js
@@ -4,7 +4,7 @@
     // tabs that dynamically load code and highlight syntax
     // see: https://github.com/pc035860/angular-highlightjs#demos
     angular
-        .module('esri-map-docs', ['ngRoute', 'ngSanitize', 'ngSelect', 'hljs', 'esri.map'])
+        .module('esri-map-docs', ['ngRoute', 'ngSanitize', 'ngAnimate', 'ngSelect', 'hljs', 'esri.map'])
         .config(function($routeProvider, appConfig) {
             $routeProvider
                 // TODO: add home page

--- a/site/app/appConfig.js
+++ b/site/app/appConfig.js
@@ -8,7 +8,7 @@
 
     var config = {
         examplePageCategories: {
-            '2D': [{
+            '2D MapView': [{
                 toc: {
                     title: 'Feature Layer',
                     description: 'Load a FeatureLayer onto a map.',
@@ -33,7 +33,7 @@
                     controllerAs: 'vm'
                 }
             }],
-            '3D': [{
+            '3D SceneView': [{
                 toc: {
                     title: 'Scene View',
                     description: 'Use the scene view directive to load a tiled basemap onto a 3D globe.',

--- a/site/app/appConfig.js
+++ b/site/app/appConfig.js
@@ -11,7 +11,7 @@
             '2D MapView': [{
                 toc: {
                     title: 'Feature Layer',
-                    description: 'Load a FeatureLayer onto a map.',
+                    description: 'Use the <esri-map-view> directive to load a FeatureLayer onto a 2D map.',
                     url: urlPrefixes.templateHref + 'feature-layer'
                 },
                 route: {
@@ -35,8 +35,8 @@
             }],
             '3D SceneView': [{
                 toc: {
-                    title: 'Scene View',
-                    description: 'Use the scene view directive to load a tiled basemap onto a 3D globe.',
+                    title: 'SceneView',
+                    description: 'Use the <esri-scene-view> directive to load a tiled basemap onto a 3D globe.',
                     url: urlPrefixes.templateHref + 'scene-view'
                 },
                 route: {
@@ -60,7 +60,7 @@
             }, {
                 toc: {
                     title: 'Data-Driven Extrusion',
-                    description: 'Extrude polygon features based on a field value using ExtrudeSymbol3DLayer in a Scene View.',
+                    description: 'Extrude polygon features based on a field value using ExtrudeSymbol3DLayer in a SceneView.',
                     url: urlPrefixes.templateHref + 'extrude-polygon'
                 },
                 route: {
@@ -72,7 +72,7 @@
             }, {
                 toc: {
                     title: 'Toggle Ground Elevation',
-                    description: 'Turn on or off the ground elevation layer in a Scene View.',
+                    description: 'Turn on or off the ground elevation layer in a SceneView.',
                     url: urlPrefixes.templateHref + 'scene-toggle-elevation'
                 },
                 route: {
@@ -85,7 +85,7 @@
             Controls: [{
                 toc: {
                     title: 'Home Button',
-                    description: 'A custom home button directive to return the Map or Scene View to its starting point.',
+                    description: 'A custom home button directive to return the MapView or SceneView to its starting point.',
                     url: urlPrefixes.templateHref + 'home-button'
                 },
                 route: {
@@ -170,7 +170,7 @@
             }, {
                 toc: {
                     title: 'Registry Pattern',
-                    description: 'Shows how to get a reference to the map object by using the registry.',
+                    description: 'Shows how to get a reference to a MapView or SceneView object by using the registry.',
                     url: urlPrefixes.templateHref + 'registry-pattern'
                 },
                 route: {
@@ -191,8 +191,8 @@
             {
                 path: '/patterns/references-to-views',
                 templateUrl: 'app/patterns/references-to-views.html',
-                title: 'Getting a Reference to the Map and Scene Views',
-                shortTitle: 'Map and Scene View References'
+                title: 'Getting a Reference to MapViews and SceneViews',
+                shortTitle: 'MapView and SceneView References'
             },
             {
                 path: '/patterns/using-creating-widgets',

--- a/site/app/examples/property-binding.html
+++ b/site/app/examples/property-binding.html
@@ -1,13 +1,13 @@
 <h2>Property Binding</h2>
 
-<p>These properties are updated directly by the map view:</p>
+<p>These properties are updated directly by the MapView:</p>
 <ul>
     <li><strong>Lat:</strong> {{ vm.mapView.center.latitude | number:3 }}, <strong>Lng:</strong> {{ vm.mapView.center.longitude | number:3 }}</li>
     <li><strong>Scale:</strong> {{ vm.mapView.scale | number:2 }}</li>
     <li><strong>Zoom:</strong> {{ vm.mapView.zoom | number:2 }}</li>
 </ul>
 
-<p>This property can be changed by interacting with the input form and the map view:</p>
+<p>This property can be changed by interacting with the input form <strong>and</strong> the MapView:</p>
 <ul>
     <li><strong>Rotation:</strong> <input type="number" ng-model="vm.mapView.rotation" /></li>
 </ul>

--- a/site/app/examples/registry-pattern.html
+++ b/site/app/examples/registry-pattern.html
@@ -28,17 +28,17 @@
 
 <div ng-controller="AnotherController as anotherCtrl">
     <p ng-show="!anotherCtrl.mapViewPoint">
-        Click the map view to see point X / Y.
+        Click the MapView to see point X / Y.
     </p>
     <p id="mapViewClickInfo" ng-show="anotherCtrl.mapViewPoint">
-        Clicked map view point X: {{ anotherCtrl.mapViewPoint.x }}, Y: {{ anotherCtrl.mapViewPoint.y }}
+        Clicked MapView point X: {{ anotherCtrl.mapViewPoint.x }}, Y: {{ anotherCtrl.mapViewPoint.y }}
     </p>
 
     <p ng-show="!anotherCtrl.sceneViewPoint">
-        Click the scene view to see point X / Y.
+        Click the SceneView to see point X / Y.
     </p>
     <p id="sceneViewClickInfo" ng-show="anotherCtrl.sceneViewPoint">
-        Clicked scene view point X: {{ anotherCtrl.sceneViewPoint.x }}, Y: {{ anotherCtrl.sceneViewPoint.y }}
+        Clicked SceneView point X: {{ anotherCtrl.sceneViewPoint.x }}, Y: {{ anotherCtrl.sceneViewPoint.y }}
     </p>
 </div>
 

--- a/site/app/examples/scene-view.html
+++ b/site/app/examples/scene-view.html
@@ -13,7 +13,7 @@
     }
 </style>
 
-<h2>Scene View</h2>
+<h2>SceneView</h2>
 
 <div class="web-gl-warning" ng-show="vm.showViewError">WebGL is not supported on your platform/browser.</div>
 

--- a/site/app/examples/webscene-slides-as-directive.js
+++ b/site/app/examples/webscene-slides-as-directive.js
@@ -37,7 +37,6 @@ angular.module('esri-map-docs')
                 self.slides = view.map.presentation.slides.toArray();
             };
 
-
             self.onSlideChange = function(slide) {
                 // handle the on-slide-change callback
                 //  by setting the scene view location to the slide's viewpoint

--- a/site/app/home/home.html
+++ b/site/app/home/home.html
@@ -1,6 +1,9 @@
 <div class="jumbotron">
     <div class="container">
-        <h1>&lt;esri-map-view/&gt;</h1>
+        <h1>
+            <span class="primary-jumbotron-title show-hide-jumbotron-title" ng-show="esriMapViewTitle">&lt;esri-map-view/&gt;</span>
+            <span class="show-hide-jumbotron-title" ng-hide="esriMapViewTitle">&lt;esri-scene-view/&gt;</span>
+        </h1>
         <p class="lead">Directives and services to help you use Esri maps in your Angular apps</p>
     </div>
 </div>

--- a/site/app/home/home.html
+++ b/site/app/home/home.html
@@ -1,8 +1,8 @@
 <div class="jumbotron">
     <div class="container">
         <h1>
-            <span class="primary-jumbotron-title show-hide-jumbotron-title" ng-show="esriMapViewTitle">&lt;esri-map-view/&gt;</span>
-            <span class="show-hide-jumbotron-title" ng-hide="esriMapViewTitle">&lt;esri-scene-view/&gt;</span>
+            <span class="primary-jumbotron-title show-hide-jumbotron-title" ng-show="esriMapViewTitle">&lt;esri-map-view&gt;</span>
+            <span class="show-hide-jumbotron-title" ng-hide="esriMapViewTitle">&lt;esri-scene-view&gt;</span>
         </h1>
         <p class="lead">Directives and services to help you use Esri maps in your Angular apps</p>
     </div>

--- a/site/app/home/home.js
+++ b/site/app/home/home.js
@@ -1,5 +1,15 @@
 'use strict';
 
 angular.module('esri-map-docs')
-    .controller('HomeCtrl', function() {
+    .controller('HomeCtrl', function($scope, $timeout) {
+        $scope.esriMapViewTitle = true;
+
+        var toggleJumbotronTitles = function() {
+            $timeout(function() {
+                $scope.esriMapViewTitle = $scope.esriMapViewTitle ? false : true;
+                toggleJumbotronTitles();
+            }, 5000);
+        };
+
+        toggleJumbotronTitles();
     });

--- a/site/app/patterns/references-to-views.html
+++ b/site/app/patterns/references-to-views.html
@@ -1,45 +1,49 @@
 <div class="row">
     <div class="col-lg-12">
-        <h2>Getting a Reference to the Map and Scene Views</h2>
-        <p>The map and scene view directives include function binding (events)
-            as a way for you to get direct references to the underlying map and
-            scene view objects from a parent controller. This will allow you to
-            manipulate those objects in ways beyond what is allowed by the
+        <h2>Getting a Reference to MapViews and SceneViews</h2>
+        <p>The <code>&lt;esri-map-view&gt;</code> and <code>&lt;esri-scene-view&gt;</code>
+            directives include function binding (events) as a way for you to get direct
+            references to the underlying MapView and SceneView objects from a parent controller.
+            They also can be registered with a service for access among different controllers.
+            This will allow you to manipulate those objects in ways beyond what is allowed by the
             declarative directive API.</p>
         
         <h3>Events</h3>
-        <p>The map and scene view directives each include both <code>on-create</code>
-            and <code>on-load</code> events that pass a reference to the underlying map or
-            scene view object to a callback function. The <code>on-create</code> event is
+        <p>The <code>&lt;esri-map-view&gt;</code> and <code>&lt;esri-scene-view&gt;</code>
+            directives each include both <code>on-create</code>
+            and <code>on-load</code> events that pass a reference to the underlying MapView or
+            SceneView object to a callback function. The <code>on-create</code> event is
             fired immediately after the view has been created (i.e. <code>new MapView()</code>)
             and the <code>on-load</code> event fires after the view's
             <a href="https://developers.arcgis.com/javascript/latest/api-reference/esri-views-MapView.html#then">promise has been resolved</a>.
         </p> 
-        <p>The map and scene view directives also include an <code>on-error</code> event
+        <p>The <code>&lt;esri-map-view&gt;</code> and <code>&lt;esri-scene-view&gt;</code>
+            directives also include an <code>on-error</code> event
             that passes the error information object if a view's promise has been rejected.
-            This can be useful, for example, if you wish to use a scene view directive but
+            This can be useful, for example, if you wish to use a <code>&lt;esri-scene-view&gt;</code> directive but
             need to <a href="https://developers.arcgis.com/javascript/latest/sample-code/scene-webgl-support/index.html">gracefully handle</a>
-            browsers that do not support WebGL. Most examples using the scene view directive
+            browsers that do not support WebGL. Most examples using the <code>&lt;esri-scene-view&gt;</code> directive
             also demonstrate how to use this binding.
         </p>
         <p>See these examples:</p>
-        <h4>On-create</h4>
+        <h5>On-create</h5>
         <ul>
             <li><a href="#/examples/search">Search</a></li>
             <li><a href="#/examples/home-button">Home Button</a></li>
             <li><a href="#/examples/property-binding">Property Binding</a></li>
         </ul>
-        <h4>On-load</h4>
+        <h5>On-load</h5>
         <ul>
-            <li><a href="#/examples/scene-view">Scene View</a></li>
+            <li><a href="#/examples/scene-view">SceneView</a></li>
             <li><a href="#/examples/scene-toggle-elevation">Toggle Ground Elevation</a></li>
             <li><a href="#/examples/webscene-slides">Work with Slides in a WebScene</a></li>
         </ul>
 
         <h3>Registry</h3>
         <p>We've also included a <a href="./docs/#/api/esri.core.factory:esriRegistry">registry service</a>
-        that you can use to get a direct reference to a map view or scene view object by setting the
-        <code>register-as</code> attribute on the map view or scene view directive.
+        that you can use to get a direct reference to a MapView or SceneView object in any controller by setting the
+        <code>register-as</code> attribute on the <code>&lt;esri-map-view&gt;</code> or
+        <code>&lt;esri-scene-view&gt;</code> directive.
         See the <a href="#/examples/registry-pattern">Registry Pattern</a> example.</p>
     </div>
 </div>

--- a/site/app/patterns/using-creating-widgets.html
+++ b/site/app/patterns/using-creating-widgets.html
@@ -17,7 +17,7 @@
             <a href="#/patterns/other-esri-classes"><code>esriLoader.require()</code></a>
             and constructed once there is
             <a href="#/patterns/references-to-views">reference to</a>
-            a map view or scene view. This pattern also recommends that you properly tear down and
+            a MapView or SceneView. This pattern also recommends that you properly tear down and
             <a href="https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Widget.html#destroy"><code>destroy()</code></a>
             widgets when Angular scope is being destroyed.
         </p>

--- a/site/docs-resources/esri.core.ngdoc
+++ b/site/docs-resources/esri.core.ngdoc
@@ -10,8 +10,8 @@ The `esri.core` module includes services used by the directives in the {@link es
 
 ### Loading Esri Modules
 
-Use {@link esri.core.factory:esriLoader esriLoader} to lazy load the Esri ArcGIS API or to load API modules.
+Use {@link esri.core.factory:esriLoader esriLoader} to lazy load the Esri ArcGIS API for JavaScript or to require individual API modules.
 
 ### Getting a Reference to a MapView or SceneView
 
-Use the {@link esri.core.factory:esriRegistry esriRegistry} to store and retrieve Esri MapView or SceneView instances for use in different controllers.
+Use {@link esri.core.factory:esriRegistry esriRegistry} to store and retrieve Esri MapView or SceneView instances for use in different controllers.

--- a/site/docs-resources/esri.core.ngdoc
+++ b/site/docs-resources/esri.core.ngdoc
@@ -10,7 +10,7 @@ The `esri.core` module includes services used by the directives in the {@link es
 
 ### Loading Esri Modules
 
-Use {@link esri.core.factory:esriLoader esriLoader} to lazy load the Esri ArcGIS API for JavaScript or to require individual API modules.
+Use {@link esri.core.factory:esriLoader esriLoader} to lazy load the ArcGIS API for JavaScript or to require individual API modules.
 
 ### Getting a Reference to a MapView or SceneView
 

--- a/site/docs-resources/esri.map.ngdoc
+++ b/site/docs-resources/esri.map.ngdoc
@@ -6,12 +6,12 @@
 
 ## `esri.map` Module
 
-The `esri.map` module includes reusable directives for map view, scene view, and related UI elements such as a home button.
+The `esri.map` module includes reusable directives for an Esri MapView, a SceneView, and related UI elements such as a home button.
 
-### Working with 2D Maps
+### Working with 2D Maps (MapView)
 
 Using the {@link esri.map.directive:esriMapView esriMapView} directive allows you to place a 2D map on the page.
 
-### Working with 3D Maps
+### Working with 3D Maps (SceneView)
 
 Using the {@link esri.map.directive:esriSceneView esriSceneView} directive allows you to place a 3D scene on the page.

--- a/site/docs-resources/index.ngdoc
+++ b/site/docs-resources/index.ngdoc
@@ -8,7 +8,7 @@
 
 ### `esri.map` Module
 
-The {@link esri.map esri.map} module includes reusable directives for map view, scene view, and related UI elements such as a home button.
+The {@link esri.map esri.map} module includes reusable directives for an Esri MapView, a SceneView, and related UI elements such as a home button.
 
 ### `esri.core` Module
 

--- a/site/index.html
+++ b/site/index.html
@@ -139,6 +139,7 @@
     <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular.js"></script>
     <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular-route.js"></script>
     <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular-sanitize.js"></script>
+    <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular-animate.js"></script>
 
     <!-- code snippet syntax highlighting -->
     <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.9.1/highlight.min.js"></script>

--- a/site/styles/main.css
+++ b/site/styles/main.css
@@ -3,6 +3,19 @@
   color: #fff;
 }
 
+.primary-jumbotron-title {
+  position: absolute;
+}
+
+.show-hide-jumbotron-title {
+  transition: opacity linear 0.75s;
+}
+
+.show-hide-jumbotron-title.ng-hide {
+  opacity: 0;
+  display: block !important;
+}
+
 /* custom page footer */
 .footer {
   position: relative;

--- a/src/core/esriLoader.js
+++ b/src/core/esriLoader.js
@@ -9,7 +9,7 @@
      * @requires $q
      *
      * @description
-     * Use `esriLoader` to lazy load the Esri ArcGIS API for JavaScript or to require individual API modules.
+     * Use `esriLoader` to lazy load the ArcGIS API for JavaScript or to require individual API modules.
      */
     angular.module('esri.core').factory('esriLoader', function ($q) {
 
@@ -19,12 +19,12 @@
          * @methodOf esri.core.factory:esriLoader
          *
          * @description
-         * Loads the Esri ArcGIS API for JavaScript.
+         * Loads the ArcGIS API for JavaScript.
          *
-         * @param {Object=} options Send a list of options of how to load the Esri ArcGIS API for JavaScript.
+         * @param {Object=} options Send a list of options of how to load the ArcGIS API for JavaScript.
          *  This defaults to `{url: '//js.arcgis.com/4.0'}`.
          *
-         * @return {Promise} Returns a $q style promise which is resolved once the Esri ArcGIS API for JavaScript has been loaded.
+         * @return {Promise} Returns a $q style promise which is resolved once the ArcGIS API for JavaScript has been loaded.
          */
         function bootstrap(options) {
             var deferred = $q.defer();
@@ -56,7 +56,7 @@
          * @name isLoaded
          * @methodOf esri.core.factory:esriLoader
          *
-         * @return {Boolean} Returns a boolean if the Esri ArcGIS API for JavaScript is already loaded.
+         * @return {Boolean} Returns a boolean if the ArcGIS API for JavaScript is already loaded.
          */
         function isLoaded() {
             return typeof window.require !== 'undefined';

--- a/src/core/esriLoader.js
+++ b/src/core/esriLoader.js
@@ -9,7 +9,7 @@
      * @requires $q
      *
      * @description
-     * Use `esriLoader` to lazy load the Esri ArcGIS API or to require individual API modules.
+     * Use `esriLoader` to lazy load the Esri ArcGIS API for JavaScript or to require individual API modules.
      */
     angular.module('esri.core').factory('esriLoader', function ($q) {
 

--- a/src/core/esriLoader.js
+++ b/src/core/esriLoader.js
@@ -9,7 +9,7 @@
      * @requires $q
      *
      * @description
-     * Use `esriLoader` to lazyload the Esri ArcGIS API or to require API modules.
+     * Use `esriLoader` to lazy load the Esri ArcGIS API or to require individual API modules.
      */
     angular.module('esri.core').factory('esriLoader', function ($q) {
 
@@ -22,9 +22,9 @@
          * Loads the Esri ArcGIS API for JavaScript.
          *
          * @param {Object=} options Send a list of options of how to load the Esri ArcGIS API for JavaScript.
-         *  Defaults to `{url: '//js.arcgis.com/4.0'}`
+         *  This defaults to `{url: '//js.arcgis.com/4.0'}`.
          *
-         * @return {Promise} Returns a $q style promise which is resolved once the ArcGIS API for JavaScript has been loaded.
+         * @return {Promise} Returns a $q style promise which is resolved once the Esri ArcGIS API for JavaScript has been loaded.
          */
         function bootstrap(options) {
             var deferred = $q.defer();
@@ -68,11 +68,11 @@
          * @methodOf esri.core.factory:esriLoader
          *
          * @description
-         * Load an Esri module using the Dojo AMD loader.
+         * Load an Esri module(s) using the Dojo AMD loader.
          *
-         * @param {String|Array} modules A string of a module or an array of modules to be loaded.
-         * @param {Function=} callback An optional function used to support AMD style loading, promise and callback are both added to the event loop, possible race condition.
-         * @return {Promise} Returns a $q style promise which is resolved once modules are loaded
+         * @param {Array|String} modules  An array of module strings (or a string of a single module) to be loaded.
+         * @param {Function=} callback An optional function used to support AMD style loading.
+         * @return {Promise} Returns a $q style promise which is resolved once modules are loaded.
          */
         function requireModule(moduleName, callback){
             var deferred = $q.defer();

--- a/src/core/esriRegistry.js
+++ b/src/core/esriRegistry.js
@@ -53,7 +53,7 @@
              * {@link esri.map.directive:esriSceneView esriSceneView}
              * for info on how to register a map using the `register-as` attribute.
              *
-             * @param {String} name Name that the view was registered with.
+             * @param {String} name The name that the view was registered with.
              *
              * @return {Promise} Returns a $q style promise which is resolved with the view once it has been loaded.
              */

--- a/src/map/EsriHomeButtonController.js
+++ b/src/map/EsriHomeButtonController.js
@@ -6,7 +6,9 @@
      * @name esri.map.controller:EsriHomeButtonController
      *
      * @description
-     * Functions to help create HomeViewModel instances.
+     * Functions to help create and manage
+     * {@link https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Home-HomeViewModel.html HomeViewModel}
+     * instances.
      *
      * @requires esri.core.factory:esriLoader
      * @requires $element
@@ -46,7 +48,7 @@
              * A new HomeViewModel will be constructed.
              * To be fully functional, the HomeViewModel requires a valid view property.
              * This will also add the directive to a view's UI position if using the
-             * optional `view-ui-position` isolate scope property.
+             * optional {@link esri.map.directive:esriHomeButton `view-ui-position`} isolate scope property.
              *
              * @param {Object} view view instance
              */
@@ -71,7 +73,7 @@
              * @methodOf esri.map.controller:EsriHomeButtonController
              *
              * @description
-             * A wrapper around the Esri JSAPI `HomeViewModel.go()` method,
+             * A wrapper around the Esri ArcGIS API for JavaScript `HomeViewModel.go()` method,
              * which is executed when the esriHomeButton is clicked.
              */
             this.go = function() {

--- a/src/map/EsriHomeButtonController.js
+++ b/src/map/EsriHomeButtonController.js
@@ -73,7 +73,7 @@
              * @methodOf esri.map.controller:EsriHomeButtonController
              *
              * @description
-             * A wrapper around the Esri ArcGIS API for JavaScript `HomeViewModel.go()` method,
+             * A wrapper around the ArcGIS API for JavaScript `HomeViewModel.go()` method,
              * which is executed when the esriHomeButton is clicked.
              */
             this.go = function() {

--- a/src/map/EsriMapViewController.js
+++ b/src/map/EsriMapViewController.js
@@ -6,7 +6,9 @@
      * @name esri.map.controller:EsriMapViewController
      *
      * @description
-     * Functions to help create MapView instances.
+     * Functions to help create
+     * {@link https://developers.arcgis.com/javascript/latest/api-reference/esri-views-MapView.html MapView}
+     * instances. This contoller is used by the {@link esri.map.directive:esriMapView esriMapView} directive.
      *
      * @requires esri.core.factory:esriLoader
      * @requires esri.core.factory:esriRegistry

--- a/src/map/EsriSceneViewController.js
+++ b/src/map/EsriSceneViewController.js
@@ -6,7 +6,9 @@
      * @name esri.map.controller:EsriSceneViewController
      *
      * @description
-     * Functions to help create SceneView instances.
+     * Functions to help create
+     * {@link https://developers.arcgis.com/javascript/latest/api-reference/esri-views-SceneView.html SceneView}
+     * instances.  This contoller is used by the {@link esri.map.directive:esriSceneView esriSceneView} directive.
      *
      * @requires esri.core.factory:esriLoader
      * @requires esri.core.factory:esriRegistry

--- a/src/map/EsriWebsceneSlidesController.js
+++ b/src/map/EsriWebsceneSlidesController.js
@@ -38,7 +38,7 @@
              * @description
              * This method is executed when an individual slide is clicked.
              * It passes the slide object to the **`on-slide-change`** bound callback function,
-             * which can be useful for manipulating an associated Esri Scene View.
+             * which can be useful for manipulating an associated Esri SceneView.
              * It also sets the clicked slide's active status to true, to assist with CSS styling.
              *
              * @param {Object} slide slide instance
@@ -50,7 +50,7 @@
                 });
                 slide.isActiveSlide = true;
 
-                // handle click action without direct reference to the Esri JSAPI
+                // handle click action without direct reference to the ArcGIS API for JavaScript
                 //  by passing the viewpoint of the slide to the onSlideChange function binding
                 if (typeof self.onSlideChange === 'function') {
                     self.onSlideChange()(slide);

--- a/src/map/esriHomeButton.js
+++ b/src/map/esriHomeButton.js
@@ -16,7 +16,7 @@
      *
      * @param {Object} view Instance of a MapView or SceneView.
      * @param {Object=} view-ui-position The MapView or SceneView UI position object which this directive
-     * can be added to, instead of element positioning with other DOM elements and CSS rules.
+     * can be added to, as an alternative to element positioning with other DOM elements and CSS rules.
      * For details on valid object properties, see the
      * {@link https://developers.arcgis.com/javascript/latest/api-reference/esri-views-ui-DefaultUI.html#add `DefaultUI.add()`}
      * **`position`** object argument.

--- a/src/map/esriHomeButton.js
+++ b/src/map/esriHomeButton.js
@@ -9,7 +9,7 @@
      * @scope
      *
      * @description
-     * This is the directive which will create a home button using the Esri ArcGIS API for JavaScript.
+     * This is the directive which will create a home button using the ArcGIS API for JavaScript.
      *
      * ## Examples
      * - {@link ../#/examples/home-button Home Button}

--- a/src/map/esriMapView.js
+++ b/src/map/esriMapView.js
@@ -9,7 +9,9 @@
      * @scope
      *
      * @description
-     * This is the directive which will create a map view using the Esri ArcGIS API for JavaScript.
+     * This is the directive which will create a
+     * {@link https://developers.arcgis.com/javascript/latest/api-reference/esri-views-MapView.html MapView}
+     * instance using the Esri ArcGIS API for JavaScript.
      * There are plenty of examples showing how to use this directive and its bound parameters.
      *
      * ## Examples
@@ -18,11 +20,13 @@
      * - {@link ../#/examples/search Search}
      * - {@link ../#/examples and more...}
      *
-     * @param {Object} map Instance of a Map.
-     * @param {Function=} on-create Callback for successful creation of the map view.
-     * @param {Function=} on-load Callback for successful loading of the map view.
-     * @param {Function=} on-error Callback for rejected/failed loading of the map view.
-     * @param {Object | String=} view-options An object or inline object hash string defining additional map view constructor options.
+     * @param {Object} map Instance of a {@link https://developers.arcgis.com/javascript/latest/api-reference/esri-Map.html Map}
+     *  or {@link https://developers.arcgis.com/javascript/latest/api-reference/esri-WebMap.html WebMap}.
+     * @param {Function=} on-create Callback for successful creation of the MapView.
+     * @param {Function=} on-load Callback for successful loading of the MapView.
+     * @param {Function=} on-error Callback for rejected/failed loading of the MapView.
+     * @param {Object | String=} view-options An object or inline object hash string defining additional
+     *  {@link https://developers.arcgis.com/javascript/latest/api-reference/esri-views-MapView.html#properties MapView properties}.
      * @param {String=} register-as A name to use when registering the view so that it can be used by other controllers.
      *  See {@link esri.core.factory:esriRegistry esriRegistry}.
      */

--- a/src/map/esriMapView.js
+++ b/src/map/esriMapView.js
@@ -11,7 +11,7 @@
      * @description
      * This is the directive which will create a
      * {@link https://developers.arcgis.com/javascript/latest/api-reference/esri-views-MapView.html MapView}
-     * instance using the Esri ArcGIS API for JavaScript.
+     * instance using the ArcGIS API for JavaScript.
      * There are plenty of examples showing how to use this directive and its bound parameters.
      *
      * ## Examples

--- a/src/map/esriSceneView.js
+++ b/src/map/esriSceneView.js
@@ -11,11 +11,11 @@
      * @description
      * This is the directive which will create a
      * {@link https://developers.arcgis.com/javascript/latest/api-reference/esri-views-SceneView.html SceneView}
-     * instance using the Esri ArcGIS API for JavaScript.
+     * instance using the ArcGIS API for JavaScript.
      * There are plenty of examples showing how to use this directive and its bound parameters.
      *
      * ## Examples
-     * - {@link ../#/examples/scene-view Scene View}
+     * - {@link ../#/examples/scene-view SceneView}
      * - {@link ../#/examples/extrude-polygon Extrude Polygon}
      * - {@link ../#/examples/scene-toggle-elevation Toggle Basemap Elevation}
      * - {@link ../#/examples and more...}

--- a/src/map/esriSceneView.js
+++ b/src/map/esriSceneView.js
@@ -9,7 +9,9 @@
      * @scope
      *
      * @description
-     * This is the directive which will create a scene view using the Esri ArcGIS API for JavaScript.
+     * This is the directive which will create a
+     * {@link https://developers.arcgis.com/javascript/latest/api-reference/esri-views-SceneView.html SceneView}
+     * instance using the Esri ArcGIS API for JavaScript.
      * There are plenty of examples showing how to use this directive and its bound parameters.
      *
      * ## Examples
@@ -18,11 +20,13 @@
      * - {@link ../#/examples/scene-toggle-elevation Toggle Basemap Elevation}
      * - {@link ../#/examples and more...}
      *
-     * @param {Object} map Instance of a Map or WebScene.
-     * @param {Function=} on-create Callback for successful creation of the scene view.
-     * @param {Function=} on-load Callback for successful loading of the scene view.
-     * @param {Function=} on-error Callback for rejected/failed loading of the scene view, for example when WebGL is not supported.
-     * @param {Object | String=} view-options An object or inline object hash string defining additional scene view constructor options.
+     * @param {Object} map Instance of a {@link https://developers.arcgis.com/javascript/latest/api-reference/esri-Map.html Map}
+     *  or {@link https://developers.arcgis.com/javascript/latest/api-reference/esri-WebScene.html WebScene}.
+     * @param {Function=} on-create Callback for successful creation of the SceneView.
+     * @param {Function=} on-load Callback for successful loading of the SceneView.
+     * @param {Function=} on-error Callback for rejected/failed loading of the SceneView, for example when WebGL is not supported.
+     * @param {Object | String=} view-options An object or inline object hash string defining additional
+     *  {@link https://developers.arcgis.com/javascript/latest/api-reference/esri-views-SceneView.html#properties SceneView properties}.
      * @param {String=} register-as A name to use when registering the view so that it can be used by other controllers.
      *  See {@link esri.core.factory:esriRegistry esriRegistry}.
      */

--- a/src/map/esriWebsceneSlides.js
+++ b/src/map/esriWebsceneSlides.js
@@ -11,18 +11,21 @@
      * @description
      * This is the directive which will create slide bookmarks for
      * {@link https://developers.arcgis.com/javascript/latest/api-reference/esri-webscene-Slide.html WebScene Slides}
-     * for the Esri ArcGIS API for JavaScript.
+     * for the ArcGIS API for JavaScript.
+     *
      * Each bookmark will include the title and screenshot of the slide, and clicking on a bookmark will
      * provide the slide object to a callback function (`on-slide-change`). For example, the slide provided
      * in the callback will have a viewpoint property that could be used to change the location of an associated Esri SceneView.
+     *
      * **Note:** this directive does not rely on any out of the box Esri widgets or view models.
+     * It demonstrates how a custom directive can be created and made to interact with other parts of the ArcGIS API for JavaScript.
      *
      * ## Styling and CSS
      * Use the following class names to supply styling to this directive:
      * - **`slides-container`**: outer-most container (`div`)
      * - **`slide`**: individual slide bookmark (`span`)
      * - **`active-slide`**: conditional class which is set by `ng-class` when an individual slide is clicked
-     * 
+     *
      * For example, to arrange slides horizontally and give a highlighted effect on the selected slide, the following styles could be used:
      * ```css
      * .slides-container {
@@ -48,7 +51,7 @@
      *
      * @param {Array} slides Array of {@link https://developers.arcgis.com/javascript/beta/api-reference/esri-webscene-Slide.html Slide} instances.
      * @param {Function=} on-slide-change Callback for handling a change in the active slide.
-     *  May be used, for example, to update the viewpoint location of an associated Esri Scene View.
+     *  It may be used, for example, to update the viewpoint location of an associated Esri SceneView.
      */
     angular.module('esri.map')
         .directive('esriWebsceneSlides', function esriWebsceneSlides() {

--- a/src/map/esriWebsceneSlides.js
+++ b/src/map/esriWebsceneSlides.js
@@ -9,10 +9,12 @@
      * @scope
      *
      * @description
-     * This is the directive which will create slide bookmarks for WebScene Slides for the Esri ArcGIS API for JavaScript.
+     * This is the directive which will create slide bookmarks for
+     * {@link https://developers.arcgis.com/javascript/latest/api-reference/esri-webscene-Slide.html WebScene Slides}
+     * for the Esri ArcGIS API for JavaScript.
      * Each bookmark will include the title and screenshot of the slide, and clicking on a bookmark will
      * provide the slide object to a callback function (`on-slide-change`). For example, the slide provided
-     * in the callback will have a viewpoint property that could be used to change the location of an associated Esri Scene View.
+     * in the callback will have a viewpoint property that could be used to change the location of an associated Esri SceneView.
      * **Note:** this directive does not rely on any out of the box Esri widgets or view models.
      *
      * ## Styling and CSS

--- a/test/property-binding.html
+++ b/test/property-binding.html
@@ -16,14 +16,14 @@
     <body>
         <h2>Property Binding</h2>
         <div ng-controller="ExampleController as exampleCtrl">
-            <p>These properties are updated directly by the map view:</p>
+            <p>These properties are updated directly by the MapView:</p>
             <ul>
                 <li><strong>Lat:</strong> {{ exampleCtrl.mapView.center.latitude | number:3 }}, <strong>Lng:</strong> {{ exampleCtrl.mapView.center.longitude | number:3 }}</li>
                 <li><strong>Scale:</strong> {{ exampleCtrl.mapView.scale | number:2 }}</li>
                 <li><strong>Zoom:</strong> {{ exampleCtrl.mapView.zoom | number:2 }}</li>
             </ul>
 
-            <p>This property can be changed by interacting with the input form and the map view:</p>
+            <p>This property can be changed by interacting with the input form <strong>and</strong> the MapView:</p>
             <ul>
                 <li><strong>Rotation:</strong> <input type="number" ng-model="exampleCtrl.mapView.rotation" /></li>
             </ul>

--- a/test/registry-pattern.html
+++ b/test/registry-pattern.html
@@ -36,17 +36,17 @@
 
         <div ng-controller="AnotherController as anotherCtrl">
             <p ng-show="!anotherCtrl.mapViewPoint">
-                Click the map view to see point X / Y.
+                Click the MapView to see point X / Y.
             </p>
             <p id="mapViewClickInfo" ng-show="anotherCtrl.mapViewPoint">
-                Clicked map view point X: {{ anotherCtrl.mapViewPoint.x }}, Y: {{ anotherCtrl.mapViewPoint.y }}
+                Clicked MapView point X: {{ anotherCtrl.mapViewPoint.x }}, Y: {{ anotherCtrl.mapViewPoint.y }}
             </p>
 
             <p ng-show="!anotherCtrl.sceneViewPoint">
-                Click the scene view to see point X / Y.
+                Click the SceneView to see point X / Y.
             </p>
             <p id="sceneViewClickInfo" ng-show="anotherCtrl.sceneViewPoint">
-                Clicked scene view point X: {{ anotherCtrl.sceneViewPoint.x }}, Y: {{ anotherCtrl.sceneViewPoint.y }}
+                Clicked SceneView point X: {{ anotherCtrl.sceneViewPoint.x }}, Y: {{ anotherCtrl.sceneViewPoint.y }}
             </p>
         </div>
 

--- a/test/scene-view.html
+++ b/test/scene-view.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no">
-        <title>Scene View</title>
+        <title>SceneView</title>
 
         <!-- load Esri CSS  -->
         <link rel="stylesheet" href="//js.arcgis.com/4.0/esri/css/main.css">
@@ -24,7 +24,7 @@
         </style>
     </head>
     <body>
-        <h2>Scene View</h2>
+        <h2>SceneView</h2>
         <div ng-controller="ExampleController as exampleCtrl">
             <esri-scene-view map="exampleCtrl.map" on-load="exampleCtrl.onViewLoaded">
                 <span id="layerToggle" ng-show="exampleCtrl.viewLoaded">


### PR DESCRIPTION
Proposed changes:
  - Standardized references throughout v2 API docs to Esri API by using the full name "Esri ArcGIS API for JavaScript", and to Esri modules by using their proper casing (e.g. "MapView" instead of "map view")

- Tried to add more links back to JSAPI 4 doc pages when referring to Esri modules in the v2 API docs

- Bonus: Added an animated toggle between the two main directives' titles in the home page jumbotron

Resolves #290 

@tomwayson please review, particularly the "Bonus" item.  Is it too much?