### PR TITLE
v1 defaults to JSAPI 3.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Upcoming changes][unreleased]
 
 ### Changed
+
+esriLoader defaults to loading JSAPI v3.18compact. Docs site uses JSAPI v3.18compact. [#304](https://github.com/Esri/angular-esri-map/issues/304)
+
 Modified esriMap `webmap-id` param to be on isolate scope rather than `attrs`, so that it can also be a value from a controller's scope. This also includes a new test page to demonstrate this change. [#297](https://github.com/Esri/angular-esri-map/pull/297) [@stephguignard](https://github.com/stephguignard)
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Once you've added the module to your application, you can use the sample code be
         <title>Angular Esri Quick Start</title>
         <meta name="viewport" content="initial-scale=1.0, user-scalable=no">
         <meta charset="utf-8">
-        <link rel="stylesheet" type="text/css" href="//js.arcgis.com/3.17/esri/css/esri.css">
+        <link rel="stylesheet" type="text/css" href="//js.arcgis.com/3.18/esri/css/esri.css">
     </head>
     <body ng-controller="MapController as vm">
         <esri-map id="map" center="vm.center" zoom="vm.zoom" basemap="topo">
@@ -61,7 +61,7 @@ Once you've added the module to your application, you can use the sample code be
         <p>Lat: {{ vm.center.lat | number:3 }}, Lng: {{ vm.center.lng | number:3 }}, Zoom: {{ vm.zoom }}</p>
 
         <!-- load Esri JSAPI -->
-        <script src="//js.arcgis.com/3.17compact"></script>
+        <script src="//js.arcgis.com/3.18compact"></script>
         <!-- load AngularJS -->
         <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular.js"></script>
         <!-- load angular-esri-map -->

--- a/site/app/examples/vector-tile-layer.html
+++ b/site/app/examples/vector-tile-layer.html
@@ -2,7 +2,7 @@
 <!-- add map to page and bind to scope map parameters -->
 <esri-map id="map" map-options="map.options">
     <esri-vector-tile-layer 
-        url="//www.arcgis.com/sharing/rest/content/items/f96366254a564adda1dc468b447ed956/resources/styles/root.json">
+        url="//www.arcgis.com/sharing/rest/content/items/bf79e422e9454565ae0cbe9553cf6471/resources/styles/root.json">
     </esri-vector-tile-layer>
 </esri-map>
 <p>Based on <a href="https://developers.arcgis.com/javascript/3/jssamples/layers_vector.html">this sample</a>.</p>

--- a/site/app/examples/vector-tile-layer.js
+++ b/site/app/examples/vector-tile-layer.js
@@ -4,7 +4,7 @@ angular.module('esri-map-docs')
         $scope.map = {
             options: {
                 center: [2.3508, 48.8567],
-                zoom: 10
+                zoom: 2
             }
         };
     });

--- a/site/docs-resources/esri.core.ngdoc
+++ b/site/docs-resources/esri.core.ngdoc
@@ -10,7 +10,7 @@ The `esri.core` module includes services used by the directives in the {@link es
 
 ### Loading Esri Modules
 
-Use {@link esri.core.factory:esriLoader esriLoader} to lazy load the Esri ArcGIS API or to load API modules.
+Use {@link esri.core.factory:esriLoader esriLoader} to lazy load the ArcGIS API for JavaScript or to load API modules.
 
 ### Creating Map and Layer Instances
 

--- a/site/index.html
+++ b/site/index.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.9.1/styles/github.min.css">
 
     <!-- load Esri CSS -->
-    <link rel="stylesheet" type="text/css" href="//js.arcgis.com/3.17/esri/css/esri.css">
+    <link rel="stylesheet" type="text/css" href="//js.arcgis.com/3.18/esri/css/esri.css">
 
     <!-- load custom styles for this app -->
     <link rel="stylesheet" type="text/css" href="styles/main.css">
@@ -139,7 +139,7 @@
 
     <!-- load Esri JavaScript API -->
     <!-- NOTE: defer is only needed b/c of UMD blocks in highlight.min.js -->
-    <script defer type="text/javascript" src="//js.arcgis.com/3.17compact"></script>
+    <script defer type="text/javascript" src="//js.arcgis.com/3.18compact"></script>
 
     <!-- load Angular -->
     <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.5.5/angular.js"></script>

--- a/src/core/esriLoader.js
+++ b/src/core/esriLoader.js
@@ -9,7 +9,7 @@
      * @requires $q
      *
      * @description
-     * Use `esriLoader` to lazyload the Esri ArcGIS API or to require API modules.
+     * Use `esriLoader` to lazy load the ArcGIS API for JavaScript or to require API modules.
      */
     angular.module('esri.core').factory('esriLoader', function ($q) {
 
@@ -19,10 +19,10 @@
          * @methodOf esri.core.factory:esriLoader
          *
          * @description
-         * Loads the Esri ArcGIS API for JavaScript.
+         * Loads the ArcGIS API for JavaScript.
          *
-         * @param {Object=} options Send a list of options of how to load the Esri ArcGIS API for JavaScript.
-         *  Defaults to `{url: 'http://js.arcgis.com/3.17compact'}`
+         * @param {Object=} options Send a list of options of how to load the ArcGIS API for JavaScript.
+         *  Defaults to `{url: '//js.arcgis.com/3.18compact'}`
          *
          * @return {Promise} Returns a $q style promise which is resolved once the ArcGIS API for JavaScript has been loaded.
          */
@@ -34,14 +34,14 @@
 
             // Don't reload API if it is already loaded
             if (isLoaded()) {
-                deferred.reject('ESRI API is already loaded.');
+                deferred.reject('ArcGIS API for JavaScript is already loaded.');
                 return deferred.promise;
             }
 
             // Create Script Object to be loaded
             var script    = document.createElement('script');
             script.type   = 'text/javascript';
-            script.src    = opts.url || window.location.protocol + '//js.arcgis.com/3.17compact';
+            script.src    = opts.url || window.location.protocol + '//js.arcgis.com/3.18compact';
 
             // Set onload callback to resolve promise
             script.onload = function() { deferred.resolve( window.require ); };
@@ -56,7 +56,7 @@
          * @name isLoaded
          * @methodOf esri.core.factory:esriLoader
          *
-         * @return {Boolean} Returns a boolean if the Esri ArcGIS API for JavaScript is already loaded.
+         * @return {Boolean} Returns a boolean if the ArcGIS API for JavaScript is already loaded.
          */
         function isLoaded() {
             return typeof window.require !== 'undefined';
@@ -79,10 +79,10 @@
 
             // Throw Error if Esri is not loaded yet
             if (!isLoaded()) {
-                deferred.reject('Trying to call esriLoader.require(), but Esri ArcGIS API has not been loaded yet. Run esriLoader.bootstrap() if you are lazy loading Esri ArcGIS API.');
+                deferred.reject('Trying to call esriLoader.require(), but the ArcGIS API for JavaScript has not been loaded yet. Run esriLoader.bootstrap() if you are lazy loading the ArcGIS API for JavaScript.');
                 return deferred.promise;
             }
-            
+
             if (typeof moduleName === 'string') {
                 require([moduleName], function (module) {
                     // grab the single module passed back from require callback and send to promise

--- a/src/map/esriMap.js
+++ b/src/map/esriMap.js
@@ -9,7 +9,7 @@
      * @scope
      *
      * @description
-     * This is the directive which will create a map using the Esri ArcGIS API for JavaScript.
+     * This is the directive which will create a map using the ArcGIS API for JavaScript.
      * There are plenty of examples showing how to use this directive and its bound parameters.
      * For additional information, we recommend the
      * {@link https://developers.arcgis.com/javascript/jsapi/map-amd.html Esri Map documentation}.

--- a/test/unit/core/esriLoader.spec.js
+++ b/test/unit/core/esriLoader.spec.js
@@ -35,8 +35,8 @@ describe('esriLoader', function() {
             });
 
             describe('when not passing url in options', function() {
-                it('should default to 3.17compact', function() {
-                    var url = window.location.protocol + '//js.arcgis.com/3.17compact';
+                it('should default to 3.18compact', function() {
+                    var url = window.location.protocol + '//js.arcgis.com/3.18compact';
                     esriLoader.bootstrap();
                     expect(document.body.appendChild.calls.argsFor(0)[0].src).toEqual(url);
                 });

--- a/test/vector-tile-layer.html
+++ b/test/vector-tile-layer.html
@@ -3,7 +3,7 @@
     <head>
         <meta name="viewport" content="initial-scale=1.0, user-scalable=no">
         <meta charset="utf-8">
-        <title>Simple Map</title>
+        <title>Vector Tile Layer</title>
 
         <!-- load Esri CSS -->
         <link rel="stylesheet" type="text/css" href="//js.arcgis.com/3.15/esri/css/esri.css">
@@ -13,8 +13,7 @@
         <!-- add map to page and bind to scope map parameters -->
         <esri-map id="map" map-options="map.options">
             <esri-vector-tile-layer 
-                url="//www.arcgis.com/sharing/rest/content/items/f96366254a564adda1dc468b447ed956/resources/styles/root.json
-                "
+                url="//www.arcgis.com/sharing/rest/content/items/bf79e422e9454565ae0cbe9553cf6471/resources/styles/root.json"
                 layer-options="{ id: 'vtl-dark-style', opacity: 0.75 }">
             </esri-vector-tile-layer>
         </esri-map>
@@ -33,7 +32,7 @@
                     $scope.map = {
                         options: {
                             center: [2.3508, 48.8567],
-                            zoom: 10
+                            zoom: 2
                         }
                     };
                 });


### PR DESCRIPTION
- Choose the appropriate base branch that you want to merge into:
  - **v1.x** for v1 (Esri JSAPI 3.x)

resolves #304 

@tomwayson please review.

Once approved and merged, I can take care of:
- [ ] deploying latest docs site to v1 gh-pages
- [ ] cutting a new v1.1.7 release