### PR TITLE
fixes bug w/ JSAPI 4.7+ by using .when() instead of .then()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Upcoming changes][unreleased]
 
-### Support
+### Fixed
+
+Uses [`.when()` instead of `.then()`](https://www.esri.com/arcgis-blog/products/js-api-arcgis/mapping/making-better-promises/) for JSAPI 4.7+ compatibility
+
+### Changed
+
+esriLoader defaults to loading JSAPI v4.8. Docs site uses JSAPI v4.8
 
 Added information to readme to clarify status of this project.
-
-### Maintenance
 
 Updated Travis CI config and package.json ("engines") to indicate the node versions that tests are expected to run on.
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ These directives can be used as-is if your mapping needs are simple, or as refer
 
 ## Status
 
-This project is no longer being actively maintained. It will not be updated or tested with the latest versions of the ArcGIS API for JavaScript and AngularJS v1.x. Ideas for new features or pull requests will likely not be reviewed or merged.
+This project is no longer being actively maintained. It will **not** be updated or tested with the latest versions of the ArcGIS API for JavaScript and AngularJS v1.x. Ideas for new features or pull requests are **not** likely to be reviewed or merged.
 
 No guarantee of future support is provided, but we will try to respond to new issues about bugs. These should include a link to an existing application or live demo (e.g. Plunkr, JS Bin, JsFiddle) where the bug can be verified, otherwise it is unlikely that we'll be able to help.
 
-You can find up to date information on [using the ArcGIS API for JavaScript in an Angular (2+) application at this Angular resources page](https://github.com/esri/jsapi-resources/tree/master/frameworks/angular). [`esri-loader`](https://github.com/esri/esri-loader) is the preferred way to load ArcGIS API for JavaScript modules in Angular (2+) applications.
+You can find up to date information on [using the ArcGIS API for JavaScript in an Angular (2+) application at this Angular resources page](https://github.com/esri/jsapi-resources/tree/master/frameworks/angular).
 
 ## Getting Started
 
@@ -68,7 +68,7 @@ Once you've added the module to your application, you can refer the sample code 
 
         <title>AngularJS Esri Quick Start</title>
 
-        <link rel="stylesheet" href="https://js.arcgis.com/4.4/esri/css/main.css">
+        <link rel="stylesheet" href="https://js.arcgis.com/4.8/esri/css/main.css">
         <style type="text/css">
             html, body, .esri-view {
                 padding: 0;
@@ -83,7 +83,7 @@ Once you've added the module to your application, you can refer the sample code 
         </esri-scene-view>
 
         <!-- load Esri JSAPI -->
-        <script src="https://js.arcgis.com/4.4/"></script>
+        <script src="https://js.arcgis.com/4.8/"></script>
         <!-- load AngularJS -->
         <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.6.5/angular.js"></script>
         <!-- load angular-esri-map -->
@@ -124,7 +124,8 @@ v1.0.0 | v1.3 - v1.5 | [v3.12+](https://developers.arcgis.com/javascript/3/) | T
 v1.1.0 | v1.3 - v1.5 | [v3.15+](https://developers.arcgis.com/javascript/3/) |
 v1.1.8 | v1.3+ | [v3.15+](https://developers.arcgis.com/javascript/3/) | Due to a breaking change in controllers at AngularJS v1.6, e2e test coverage has been performed with v1.3, but will only continue with v1.6. See [CHANGELOG](https://github.com/Esri/angular-esri-map/blob/v1.x/CHANGELOG.md#v118).
 v2.0.0 | v1.3 - v1.5 | [v4.0+](https://developers.arcgis.com/javascript/) | Test coverage included for AngularJS v1.3.
-v2.0.2 | v1.3+ | [v4.0+](https://developers.arcgis.com/javascript/) | Due to a breaking change in controllers at AngularJS v1.6, e2e test coverage has been performed with v1.3, but will only continue with v1.6. See [CHANGELOG](https://github.com/Esri/angular-esri-map/blob/master/CHANGELOG.md#v202).
+v2.0.2 | v1.3+ | [v4.0 - v4.6](https://developers.arcgis.com/javascript/) | Due to a breaking change in controllers at AngularJS v1.6, e2e test coverage has been performed with v1.3, but will only continue with v1.6. See [CHANGELOG](https://github.com/Esri/angular-esri-map/blob/master/CHANGELOG.md#v202).
+v2.0.5 | v1.3+ | [v4.6+](https://developers.arcgis.com/javascript/) | Uses [`.when()` instead of `.then()`](https://www.esri.com/arcgis-blog/products/js-api-arcgis/mapping/making-better-promises/)
 
 ## Resources
 
@@ -142,7 +143,7 @@ v2.0.2 | v1.3+ | [v4.0+](https://developers.arcgis.com/javascript/) | Due to a b
 
 ## What about Angular 2?
 
-You can find up to date information on [using the ArcGIS API for JavaScript in an Angular (2+) application at this Angular resources page](https://github.com/esri/jsapi-resources/tree/master/frameworks/angular). [`esri-loader`](https://github.com/esri/esri-loader) is the preferred way to load ArcGIS API for JavaScript modules in Angular (2+) applications.
+You can find up to date information on [using the ArcGIS API for JavaScript in an Angular (2+) application at this Angular resources page](https://github.com/esri/jsapi-resources/tree/master/frameworks/angular).
 
 ## What about Ionic?
 

--- a/README.md
+++ b/README.md
@@ -120,12 +120,12 @@ See the compatibility table below for details.
 
 angular-esri-map | AngularJS | ArcGIS API for JavaScript | Notes
 --- | --- | --- | ---
-v1.0.0 | v1.3 - v1.5 | [v3.12+](https://developers.arcgis.com/javascript/3/) | Test coverage included for AngularJS v1.3.
-v1.1.0 | v1.3 - v1.5 | [v3.15+](https://developers.arcgis.com/javascript/3/) |
-v1.1.8 | v1.3+ | [v3.15+](https://developers.arcgis.com/javascript/3/) | Due to a breaking change in controllers at AngularJS v1.6, e2e test coverage has been performed with v1.3, but will only continue with v1.6. See [CHANGELOG](https://github.com/Esri/angular-esri-map/blob/v1.x/CHANGELOG.md#v118).
-v2.0.0 | v1.3 - v1.5 | [v4.0+](https://developers.arcgis.com/javascript/) | Test coverage included for AngularJS v1.3.
+v1.0.0 | v1.3 - v1.5 | [v3.12 - 3.21](https://developers.arcgis.com/javascript/3/) | Test coverage included for AngularJS v1.3.
+v1.1.0 | v1.3 - v1.5 | [v3.15 - 3.21](https://developers.arcgis.com/javascript/3/) |
+v1.1.8 | v1.3+ | [v3.12 - 3.21](https://developers.arcgis.com/javascript/3/) | Due to a breaking change in controllers at AngularJS v1.6, e2e test coverage has been performed with v1.3, but will only continue with v1.6. See [CHANGELOG](https://github.com/Esri/angular-esri-map/blob/v1.x/CHANGELOG.md#v118).
+v2.0.0 | v1.3 - v1.5 | [v4.0 - v4.6](https://developers.arcgis.com/javascript/) | Test coverage included for AngularJS v1.3.
 v2.0.2 | v1.3+ | [v4.0 - v4.6](https://developers.arcgis.com/javascript/) | Due to a breaking change in controllers at AngularJS v1.6, e2e test coverage has been performed with v1.3, but will only continue with v1.6. See [CHANGELOG](https://github.com/Esri/angular-esri-map/blob/master/CHANGELOG.md#v202).
-v2.0.5 | v1.3+ | [v4.6+](https://developers.arcgis.com/javascript/) | Uses [`.when()` instead of `.then()`](https://www.esri.com/arcgis-blog/products/js-api-arcgis/mapping/making-better-promises/)
+v2.0.5 | v1.3+ | [v4.6 - v4.8](https://developers.arcgis.com/javascript/) | Uses [`.when()` instead of `.then()`](https://www.esri.com/arcgis-blog/products/js-api-arcgis/mapping/making-better-promises/)
 
 ## Resources
 

--- a/site/app/examples/chaining-promises.js
+++ b/site/app/examples/chaining-promises.js
@@ -97,7 +97,7 @@ angular.module('esri-map-docs')
             // zooms to the buffer location
             function zoomTo(geom) {
                 // when the view is ready
-                return self.view.then(function() {
+                return self.view.when(function() {
                     // zoom to the buffer geometry
                     return self.view.goTo({
                         target: geom,

--- a/site/app/examples/scene-view.js
+++ b/site/app/examples/scene-view.js
@@ -59,7 +59,7 @@ angular.module('esri-map-docs')
 
                 // Once the housing layer has loaded,
                 // the view will animate to it's initial extent.
-                housingLyr.then(function() {
+                housingLyr.when(function() {
                     view.goTo(housingLyr.fullExtent);
                 });
 

--- a/site/index.html
+++ b/site/index.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.9.1/styles/github.min.css">
 
     <!-- load Esri CSS -->
-    <link rel="stylesheet" href="https://js.arcgis.com/4.4/esri/css/main.css">
+    <link rel="stylesheet" href="https://js.arcgis.com/4.8/esri/css/main.css">
 
     <!-- load custom styles for this app -->
     <link rel="stylesheet" type="text/css" href="styles/main.css">
@@ -139,7 +139,7 @@
 
     <!-- load Esri JavaScript API -->
     <!-- NOTE: defer is only needed b/c of UMD blocks in highlight.min.js -->
-    <script defer type="text/javascript" src="https://js.arcgis.com/4.4/"></script>
+    <script defer type="text/javascript" src="https://js.arcgis.com/4.8/"></script>
 
     <!-- load Angular -->
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/angularjs/1.6.5/angular.js"></script>

--- a/src/core/esriLoader.js
+++ b/src/core/esriLoader.js
@@ -22,7 +22,7 @@
          * Loads the ArcGIS API for JavaScript.
          *
          * @param {Object=} options Send a list of options of how to load the ArcGIS API for JavaScript.
-         *  This defaults to `{url: 'https://js.arcgis.com/4.4'}`.
+         *  This defaults to `{url: 'https://js.arcgis.com/4.8'}`.
          *
          * @return {Promise} Returns a $q style promise which is resolved once the ArcGIS API for JavaScript has been loaded.
          */
@@ -41,7 +41,7 @@
             // Create Script Object to be loaded
             var script    = document.createElement('script');
             script.type   = 'text/javascript';
-            script.src    = opts.url || window.location.protocol + '//js.arcgis.com/4.4';
+            script.src    = opts.url || window.location.protocol + '//js.arcgis.com/4.8';
 
             // Set onload callback to resolve promise
             script.onload = function() { deferred.resolve( window.require ); };

--- a/src/map/EsriMapViewController.js
+++ b/src/map/EsriMapViewController.js
@@ -94,7 +94,7 @@
                             self.onCreate()(self.view);
                         }
 
-                        self.view.then(function() {
+                        self.view.when(function() {
                             if (typeof self.onLoad() === 'function') {
                                 $scope.$apply(function() {
                                     self.onLoad()(self.view);

--- a/src/map/EsriSceneViewController.js
+++ b/src/map/EsriSceneViewController.js
@@ -97,7 +97,7 @@
                             self.onCreate()(self.view);
                         }
 
-                        self.view.then(function() {
+                        self.view.when(function() {
                             if (typeof self.onLoad() === 'function') {
                                 $scope.$apply(function() {
                                     self.onLoad()(self.view);

--- a/test/chaining-promises.html
+++ b/test/chaining-promises.html
@@ -140,7 +140,7 @@
                         // zooms to the buffer location
                         function zoomTo(geom) {
                             // when the view is ready
-                            return self.view.then(function() {
+                            return self.view.when(function() {
                                 // zoom to the buffer geometry
                                 return self.view.goTo({
                                     target: geom,

--- a/test/unit/core/esriLoader.spec.js
+++ b/test/unit/core/esriLoader.spec.js
@@ -35,8 +35,8 @@ describe('esriLoader', function() {
             });
 
             describe('when not passing url in options', function() {
-                it('should default to 4.4', function() {
-                    var url = window.location.protocol + '//js.arcgis.com/4.4';
+                it('should default to the correct version from the CDN', function() {
+                    var url = window.location.protocol + '//js.arcgis.com/4.8';
                     esriLoader.bootstrap();
                     expect(document.body.appendChild.calls.argsFor(0)[0].src).toEqual(url);
                 });


### PR DESCRIPTION
- Choose the appropriate base branch that you want to merge into:
  - **v1.x** for v1 (Esri JSAPI 3.x)
  - **master** for v2 (Esri JSAPI 4.x)

master

- Describe the proposed changes:
  - Is there an example or test page to demonstrate any new or changed features?
  - Does your PR include appropriate unit or functional tests for source code alterations?

fixes bug w/ JSAPI 4.7+ by using .when() instead of .then()
also defaults to 4.8
unit tests pass, but I can't get e2e to run
also removes "esri-loader is preferred for Angular (2+)" from README

- Provide a reference to any related issue.
#350 
